### PR TITLE
Allow namespaces to be provided as a comma-separated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ By default the tool will run diagnostics for the `elastic-system` namespace, whe
 
 To run diagnostics, for example, for namespaces `a` and `b` instead:
 ```shell
-eck-diagnostics -r a -r b
+eck-diagnostics -r a,b
 ```
 
 A full list of available options is reproduced here and is also printed when calling the `eck-diagnostics` binary with the `--help` or `-h` flag:
@@ -29,9 +29,9 @@ Flags:
       --eck-version string                 ECK version in use, will try to autodetect if not specified
   -h, --help                               help for eck-diagnostics
       --kubeconfig string                  optional path to kube config, defaults to $HOME/.kube/config
-  -o, --operator-namespaces stringArray    Namespace(s) in which operator(s) are running (default [elastic-system])
+  -o, --operator-namespaces strings        Comma-separated list of namespace(s) in which operator(s) are running (default [elastic-system])
       --output-directory string            Path where to output diagnostic results
-  -r, --resources-namespaces stringArray   Namespace(s) in which resources are managed (default [default])
+  -r, --resources-namespaces strings       Comma-separated list of namespace(s) in which resources are managed (default [default])
       --verbose                            Verbose mode
 
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,8 +38,8 @@ func main() {
 			return internal.Run(diagParams)
 		},
 	}
-	cmd.Flags().StringArrayVarP(&diagParams.OperatorNamespaces, "operator-namespaces", "o", []string{"elastic-system"}, "Namespace(s) in which operator(s) are running")
-	cmd.Flags().StringArrayVarP(&diagParams.ResourcesNamespaces, "resources-namespaces", "r", []string{"default"}, "Namespace(s) in which resources are managed")
+	cmd.Flags().StringSliceVarP(&diagParams.OperatorNamespaces, "operator-namespaces", "o", []string{"elastic-system"}, "Comma-separated list of namespace(s) in which operator(s) are running")
+	cmd.Flags().StringSliceVarP(&diagParams.ResourcesNamespaces, "resources-namespaces", "r", []string{"default"}, "Comma-separated list of namespace(s) in which resources are managed")
 	cmd.Flags().StringVar(&diagParams.ECKVersion, "eck-version", "", "ECK version in use, will try to autodetect if not specified")
 	cmd.Flags().StringVar(&diagParams.OutputDir, "output-directory", "", "Path where to output diagnostic results")
 	cmd.Flags().StringVar(&diagParams.Kubeconfig, "kubeconfig", "", "optional path to kube config, defaults to $HOME/.kube/config")


### PR DESCRIPTION
This is a proposal to use `StringSliceVarP` instead of `StringArrayVarP`, it allows the user to provide a namespaces list as a comma-separated strings, for example:

```
> eck-diagnostics -o elastic-system1,elastic-system1 -r foo,foo2
```

I _think_ it is more convenient than providing the flags multiple times, not strong opinion though, feel free to discard this pr.
