### PR TITLE
Introduce individual timeouts for each stack application being diagnosed

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -9,21 +9,19 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"time"
+
+	"github.com/elastic/eck-diagnostics/internal/log"
 
 	"github.com/elastic/eck-diagnostics/internal/archive"
 	"k8s.io/apimachinery/pkg/util/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth on gke
 )
 
-var (
-	logBuffer bytes.Buffer
-	logger    = log.New(io.MultiWriter(os.Stdout, &logBuffer), "", log.LstdFlags)
-)
+var logger = log.Logger
 
 // Params is a collection of parameters controlling the extraction of diagnostic data.
 // See the main command for explanation of individual parameters.
@@ -193,7 +191,7 @@ LOOP:
 		}
 	}
 
-	addDiagnosticLogToArchive(zipFile, &logBuffer)
+	addDiagnosticLogToArchive(zipFile, &log.Buffer)
 
 	if err := zipFile.Close(); err != nil {
 		// log the errors here and don't return them to the invoking command as we don't want usage help to be

--- a/internal/diag.go
+++ b/internal/diag.go
@@ -14,9 +14,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/elastic/eck-diagnostics/internal/log"
-
 	"github.com/elastic/eck-diagnostics/internal/archive"
+	"github.com/elastic/eck-diagnostics/internal/log"
 	"k8s.io/apimachinery/pkg/util/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // auth on gke
 )

--- a/internal/extraction/extraction.go
+++ b/internal/extraction/extraction.go
@@ -1,0 +1,191 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package extraction
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/elastic/eck-diagnostics/internal/log"
+
+	"github.com/elastic/eck-diagnostics/internal/archive"
+)
+
+var logger = log.Logger
+
+type RemoteSource struct {
+	Namespace    string // de-normalized for convenience
+	PodName      string
+	Typ          string
+	ResourceName string
+	PodOutputDir string
+}
+
+// sourceDirPrefix the directory prefix the stack support-diagnostics tool uses in the archive it creates.
+func (j *RemoteSource) sourceDirPrefix() string {
+	prefix := "api-diagnostics"
+	if j.Typ == "kibana" {
+		prefix = fmt.Sprintf("%s-%s", j.Typ, prefix)
+	}
+	return prefix
+}
+
+// outputDirPrefix the directory hierarchy we want to use in the archive created by this tool. It should be the Namespace
+// of the resource we are creating diagnostics for followed by the type (elasticserach or kibana currently) and the name
+// of the resource.
+func (j *RemoteSource) outputDirPrefix() string {
+	return archive.Path(j.Namespace, j.Typ, j.ResourceName)
+}
+
+// UntarIntoZip extracts the files transferred via tar from the Pod into the given ZipFile.
+func UntarIntoZip(reader *io.PipeReader, job RemoteSource, file *archive.ZipFile, verbose bool) error {
+	tarReader := tar.NewReader(reader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return err
+			}
+			break
+		}
+		remoteFilename := header.Name
+		// remove the path prefix on the Pod
+		relOutputDir := fmt.Sprintf("%s/", strings.TrimPrefix(job.PodOutputDir, "/"))
+		relativeFilename := strings.TrimPrefix(remoteFilename, relOutputDir)
+		// stack diagnostics create output in a directory called api-diagnostics-{{.Timestamp}}
+		if !strings.HasPrefix(relativeFilename, job.sourceDirPrefix()) {
+			if verbose {
+				logger.Printf("Ignoring file %s in tar from %s diagnostics\n", header.Name, job.ResourceName)
+			}
+			continue
+		}
+		manifest := archive.StackDiagnosticManifest{DiagType: job.Typ}
+
+		switch {
+		case strings.HasSuffix(relativeFilename, "tar.gz"):
+			manifest.DiagPath = job.outputDirPrefix()
+			if err := RepackageTarGzip(tarReader, job.outputDirPrefix(), file); err != nil {
+				return err
+			}
+		case strings.HasSuffix(relativeFilename, ".zip"):
+			manifest.DiagPath = job.outputDirPrefix()
+			if err := RepackageZip(tarReader, job.outputDirPrefix(), file); err != nil {
+				return err
+			}
+		default:
+			path := archive.Path(job.Namespace, job.Typ, job.ResourceName, relativeFilename)
+			manifest.DiagPath = path
+			out, err := file.Create(path)
+			if err != nil {
+				return err
+			}
+			// accept decompression bomb for CLI as we control the src
+			if _, err := io.Copy(out, tarReader); err != nil { //nolint:gosec
+				return err
+			}
+		}
+		file.AddManifestEntry(manifest)
+	}
+	return nil
+}
+
+// RepackageTarGzip repackages the *.tar.gz archives produced by the support diagnostics tool into the given ZipFile.
+func RepackageTarGzip(in io.Reader, outputDirPrefix string, zipFile *archive.ZipFile) error {
+	gzReader, err := gzip.NewReader(in)
+	if err != nil {
+		return err
+	}
+	topLevelDir := ""
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return err
+			}
+			break
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if topLevelDir == "" {
+				topLevelDir = header.Name
+			}
+			continue
+		case tar.TypeReg:
+			out, err := zipFile.Create(toOutputPath(header.Name, topLevelDir, outputDirPrefix))
+			if err != nil {
+				return err
+			}
+			// accept decompression bomb for CLI tool and we control the src
+			_, err = io.Copy(out, tarReader) //nolint:gosec
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// RepackageZip repackages the *.zip file produced by the support diagnostics tool into the zip file produced by this tool
+func RepackageZip(in io.Reader, outputDirPrefix string, zipFile *archive.ZipFile) error {
+	// it seems the only way to repack a zip archive is to completely read it into memory first
+	b := new(bytes.Buffer)
+	if _, err := b.ReadFrom(in); err != nil {
+		return err
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(b.Bytes()), int64(b.Len()))
+	if err != nil {
+		return err
+	}
+	// api-diagnostics creates a common top folder we don't need when repackaging
+	topLevelDir := ""
+	for _, f := range zipReader.File {
+		// skip all the directory entries
+		if f.UncompressedSize64 == 0 {
+			continue
+		}
+		// extract the tld first time round
+		if topLevelDir == "" {
+			topLevelDir = archive.RootDir(f.Name)
+		}
+		out, err := zipFile.Create(toOutputPath(f.Name, topLevelDir, outputDirPrefix))
+		if err != nil {
+			return err
+		}
+		if err := copyFromZip(f, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyFromZip writes the contents of file f from a zip file into out.
+func copyFromZip(f *zip.File, out io.Writer) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	if _, err := io.Copy(out, rc); err != nil { //nolint:gosec
+		return err
+	}
+	return nil
+}
+
+// toOutputPath removes the path prefix topLevelDir from original and re-bases it in outputDirPrefix.
+func toOutputPath(original, topLevelDir, outputDirPrefix string) string {
+	// topLevelDir should always be a Unix-style path like /api-diagnostics-20210907-133527 so a simple trim should suffice
+	// and avoids filepath.* functions that would insert platform specific path elements that are incompatible with
+	// the ZIP format.
+	return archive.Path(outputDirPrefix, strings.TrimPrefix(original, topLevelDir))
+}

--- a/internal/extraction/extraction.go
+++ b/internal/extraction/extraction.go
@@ -14,13 +14,14 @@ import (
 	"io"
 	"strings"
 
-	"github.com/elastic/eck-diagnostics/internal/log"
-
 	"github.com/elastic/eck-diagnostics/internal/archive"
+	"github.com/elastic/eck-diagnostics/internal/log"
 )
 
 var logger = log.Logger
 
+// RemoteSource describes are remote (i.e. in-cluster) source of diagnostic data in a Pod that has run the Elastic
+// stack support-diagnostics and is waiting for the diagnostic data to be extracted.
 type RemoteSource struct {
 	Namespace    string // de-normalized for convenience
 	PodName      string

--- a/internal/extraction/extraction.go
+++ b/internal/extraction/extraction.go
@@ -20,7 +20,7 @@ import (
 
 var logger = log.Logger
 
-// RemoteSource describes are remote (i.e. in-cluster) source of diagnostic data in a Pod that has run the Elastic
+// RemoteSource describes a remote (i.e. in-cluster) source of diagnostic data in a Pod that has run the Elastic
 // stack support-diagnostics and is waiting for the diagnostic data to be extracted.
 type RemoteSource struct {
 	Namespace    string // de-normalized for convenience
@@ -40,7 +40,7 @@ func (j *RemoteSource) sourceDirPrefix() string {
 }
 
 // outputDirPrefix the directory hierarchy we want to use in the archive created by this tool. It should be the Namespace
-// of the resource we are creating diagnostics for followed by the type (elasticserach or kibana currently) and the name
+// of the resource we are creating diagnostics for followed by the type (elasticsearch or kibana currently) and the name
 // of the resource.
 func (j *RemoteSource) outputDirPrefix() string {
 	return archive.Path(j.Namespace, j.Typ, j.ResourceName)
@@ -125,7 +125,7 @@ func RepackageTarGzip(in io.Reader, outputDirPrefix string, zipFile *archive.Zip
 			if err != nil {
 				return err
 			}
-			// accept decompression bomb for CLI tool and we control the src
+			// accept decompression bomb for CLI tool as we control the src
 			_, err = io.Copy(out, tarReader) //nolint:gosec
 			if err != nil {
 				return err
@@ -135,7 +135,7 @@ func RepackageTarGzip(in io.Reader, outputDirPrefix string, zipFile *archive.Zip
 	return nil
 }
 
-// RepackageZip repackages the *.zip file produced by the support diagnostics tool into the zip file produced by this tool
+// RepackageZip repackages the *.zip file produced by the support diagnostics tool into the zip file produced by this tool.
 func RepackageZip(in io.Reader, outputDirPrefix string, zipFile *archive.ZipFile) error {
 	// it seems the only way to repack a zip archive is to completely read it into memory first
 	b := new(bytes.Buffer)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -12,6 +12,9 @@ import (
 )
 
 var (
+	// Buffer containing all log statements made through the logger, so that they can be included in the diagnostic archive.
 	Buffer bytes.Buffer
+
+	// Logger to be used by this program. Available in its own package to avoid import cycles.
 	Logger = log.New(io.MultiWriter(os.Stdout, &Buffer), "", log.LstdFlags)
 )

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,17 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package log
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+)
+
+var (
+	Buffer bytes.Buffer
+	Logger = log.New(io.MultiWriter(os.Stdout, &Buffer), "", log.LstdFlags)
+)

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -139,7 +139,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 		return err
 	}
 
-	diagnosticType, shortType := ds.diagnosticTypeForApplication(typ)
+	diagnosticType, shortType := diagnosticTypeForApplication(typ)
 
 	buffer := new(bytes.Buffer)
 	err = tpl.Execute(buffer, map[string]interface{}{
@@ -203,7 +203,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 
 // diagnosticTypeForApplication return the diagnosticType as expected by the stack diagnostics tool and a short type
 // matching the shorthand used by ECK in service names for the given application type.
-func (ds *diagJobState) diagnosticTypeForApplication(typ string) (string, string) {
+func diagnosticTypeForApplication(typ string) (string, string) {
 	switch typ {
 	case elasticsearchJob:
 		return "api", "es"

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -42,7 +42,7 @@ const (
 	podOutputDir         = "/diagnostic-output"
 	podMainContainerName = "offer-output"
 
-	// names used to identify different stack diagnostc job types (need to match the names of the corresponding CRDs)
+	// names used to identify different stack diagnostic job types (need to match the names of the corresponding CRDs)
 	elasticsearchJob = "elasticsearch"
 	kibanaJob        = "kibana"
 )
@@ -201,7 +201,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 	return nil
 }
 
-// diagnosticTypeForApplication return the diagnosticType as expected by the stack diagnostics tool and a short type
+// diagnosticTypeForApplication returns the diagnosticType as expected by the stack diagnostics tool and a short type
 // matching the shorthand used by ECK in service names for the given application type.
 func diagnosticTypeForApplication(typ string) (string, string) {
 	switch typ {

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -170,6 +170,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 			PodOutputDir: podOutputDir,
 		},
 	}
+	// start a dedicated timer for each job and terminate the job when the timer expires.
 	go func(j *diagJob) {
 		timer := time.NewTimer(jobTimeout)
 		<-timer.C


### PR DESCRIPTION
Fixes #55 

Currently we have one 5 minute timeout per namespace for running all support-diagnostics in that namespace. This replaces the global timeout with individual timeouts for each Kibana/Elasticsearch that we extract diagnostics from. It also moves code around into separate packages mainly to untangle dependencies and avoid import cycles. 

There is still room for more improvement that is not addressed in this PR: 
*  we could run support diagnostics in parallel in all namespaces and only serialise the actual copying of data from the Kubernetes cluster to the local machine (I have a vague recollection that doing that in parallel does not work well)
