### PR TITLE
Add requests/limits to stack diagnostics Pod

### DIFF
--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -45,10 +45,10 @@ spec:
           while true; do sleep 1; done;
       resources:
         requests:
-          memory: 5Mi
+          memory: 16Mi
           cpu: 50m
         limits:
-          memory: 5Mi
+          memory: 16Mi
           cpu: 50m
   volumes:
     - name: output

--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -21,6 +21,13 @@ spec:
       command: [sh, -c]
       args:
         - ./diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify -u elastic --passwordText $ES_PW {{if .TLS}}-s --noVerify{{end}} -o {{ .OutputDir }}
+      resources:
+        requests:
+          memory: 20Mi
+          cpu: 100m
+        limits:
+          memory: 50Mi
+          cpu: 100m
       volumeMounts:
         - name: output
           mountPath: {{ .OutputDir }}
@@ -36,6 +43,13 @@ spec:
       args:
         - |
           while true; do sleep 1; done;
+      resources:
+        requests:
+          memory: 1Mi
+          cpu: 50m
+        limits:
+          memory: 2Mi
+          cpu: 50m
   volumes:
     - name: output
       emptyDir: {}

--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -26,8 +26,8 @@ spec:
           memory: 20Mi
           cpu: 100m
         limits:
-          memory: 50Mi
-          cpu: 100m
+          memory: 2Gi
+          cpu: 1
       volumeMounts:
         - name: output
           mountPath: {{ .OutputDir }}
@@ -45,10 +45,10 @@ spec:
           while true; do sleep 1; done;
       resources:
         requests:
-          memory: 1Mi
+          memory: 5Mi
           cpu: 50m
         limits:
-          memory: 2Mi
+          memory: 5Mi
           cpu: 50m
   volumes:
     - name: output


### PR DESCRIPTION
Fixes #72 

Sets limits/requests to allow deployment of stack diagnostics Pods into namespaces that have quotas configured. I estimated the numbers based on a few test runs as shown in the screenshot below.

![Screenshot 2022-01-14 at 14 52 07](https://user-images.githubusercontent.com/697790/149526319-dceb6b5f-ab8e-431d-9db9-39ac4e9abb08.png)
