### PR TITLE
Add storageclass to diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-export VERSION ?= 1.0.0
+export VERSION ?= 1.1.0
 export GOBIN = $(shell pwd)/bin
 
 SNAPSHOT ?= true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following Kubernetes resources are retrieved from the cluster being diagnose
 * PodSecurityPolicy
 * ClusterRole
 * ClusterRoleBindings
+* StorageClass
 
 ### In all operator and workload resource namespaces 
 * StatefulSet

--- a/internal/diag.go
+++ b/internal/diag.go
@@ -89,6 +89,9 @@ func Run(params Params) error {
 		"podsecuritypolicies.json": func(writer io.Writer) error {
 			return kubectl.Get("podsecuritypolicies", "", writer)
 		},
+		"storageclasses.json": func(writer io.Writer) error {
+			return kubectl.Get("storageclasses", "", writer)
+		},
 		"clusterroles.txt": func(writer io.Writer) error {
 			return kubectl.Describe("clusterroles", "elastic", "", writer)
 		},


### PR DESCRIPTION
closes #86 

Adds all storage classes within a cluster to the eck diagnostics that are pulled, named `storageclasses.json`.