### PR TITLE
Do not automount service account tokens in the diagnostic pods

### DIFF
--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: eck-diagnostics
 spec:
   terminationGracePeriodSeconds: 0
+  automountServiceAccountToken: false
   containers:
     - name: {{ .MainContainerName }}
       image: {{ .DiagnosticImage }}


### PR DESCRIPTION
The diagnostic Pods do not need to interact with the Kubernetes API so we should not auto mount the service account token