### PR TITLE
Upgrade to support-diagnostics 8.4.0

### DIFF
--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:8.2.8"
+	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:8.4.0"
 
 	podOutputDir         = "/diagnostic-output"
 	podMainContainerName = "stack-diagnostics"


### PR DESCRIPTION
`docker.elastic.co/eck-dev/support-diagnostics:8.4.0` has been pushed.

Resolves #113.