### PR TITLE
Run support-diagnostics as non-root user

### DIFF
--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -12,6 +12,9 @@ spec:
     - name: {{ .MainContainerName }}
       image: {{ .DiagnosticImage }}
       imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
       env:
         - name: ES_PW
           valueFrom:
@@ -24,14 +27,15 @@ spec:
       command: [sh, -c]
       args:
         - |
-          ./diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify -u elastic --passwordText $ES_PW {{if .TLS}}-s --noVerify{{end}} -o {{ .OutputDir }}
-          touch /ready
+          cd {{ .OutputDir }}
+          /support-diagnostics/diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify -u elastic --passwordText $ES_PW {{if .TLS}}-s --noVerify{{end}} -o .
+          touch ready
           while true; do sleep 1; done;
       readinessProbe:
         exec:
           command:
             - cat
-            - /ready
+            - {{ .OutputDir }}/ready
       resources:
         requests:
           memory: 20Mi


### PR DESCRIPTION
This commit changes the job used to run the support-diagnostics to use a security context with a non-root user. The command arguments and the readiness probe are updated so that everything is done under the output directory where the user has write permissions (the utility writes a startup.log file and we write an empty ready file).

Relates to #120.