### PR TITLE
Add Logstash support

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -143,6 +143,7 @@ func Run(params Params) error {
 		"common.k8s.elastic.co/type=beat",              // 1.2.0
 		"common.k8s.elastic.co/type=agent",             // 1.4.0
 		"common.k8s.elastic.co/type=maps",              // 1.6.0
+		"common.k8s.elastic.co/type=logstash",          // 2.8.0
 	}
 
 	selectors := make([]labels.Selector, len(operatorLabels))
@@ -205,6 +206,11 @@ LOOP:
 		if maxOperatorVersion.AtLeast(version.MustParseSemantic("1.6.0")) {
 			zipFile.Add(getResources(kubectl.GetByName, ns, namespaceFilters, []string{
 				"elasticmapsserver",
+			}))
+		}
+		if maxOperatorVersion.AtLeast(version.MustParseSemantic("2.8.0")) {
+			zipFile.Add(getResources(kubectl.GetByName, ns, namespaceFilters, []string{
+				"logstash",
 			}))
 		}
 

--- a/internal/extraction/extraction.go
+++ b/internal/extraction/extraction.go
@@ -34,7 +34,7 @@ type RemoteSource struct {
 func (j *RemoteSource) sourceDirPrefix() string {
 	prefix := "api-diagnostics"
 	switch j.Typ {
-	case "kibana":
+	case "kibana", "logstash":
 		prefix = fmt.Sprintf("%s-%s", j.Typ, prefix)
 	case "agent":
 		prefix = ""

--- a/internal/filters/filters.go
+++ b/internal/filters/filters.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	// ValidTypes are the valid types of Elastic resources that are supported by the filtering system.
-	ValidTypes = []string{"agent", "apm", "beat", "elasticsearch", "enterprisesearch", "kibana", "maps"}
+	ValidTypes = []string{"agent", "apm", "beat", "elasticsearch", "enterprisesearch", "kibana", "maps", "logstash"}
 	Empty      = Filters{}
 )
 

--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -15,12 +15,14 @@ spec:
       securityContext:
         runAsUser: 1000
         allowPrivilegeEscalation: false
+      {{ if .ESName }}
       env:
         - name: ES_PW
           valueFrom:
             secretKeyRef:
               name: {{ .ESName }}-es-elastic-user
               key: elastic
+      {{ end }}
       volumeMounts:
         - name: output
           mountPath: {{ .OutputDir }}
@@ -28,7 +30,10 @@ spec:
       args:
         - |
           cd {{ .OutputDir }}
-          /support-diagnostics/diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify -u elastic --passwordText $ES_PW {{if .TLS}}-s --noVerify{{end}} -o .
+          /support-diagnostics/diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify \
+            {{if .ESName}} -u elastic --passwordText $ES_PW{{end}} \
+            {{if .TLS}} -s --noVerify {{end}} \
+            -o .
           touch ready
           while true; do sleep 1; done;
       readinessProbe:

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -44,9 +44,13 @@ const (
 	// names used to identify different stack diagnostic job types (need to match the names of the corresponding CRDs)
 	elasticsearchJob = "elasticsearch"
 	kibanaJob        = "kibana"
+	logstashJob      = "logstash"
 )
 
 var (
+	// supportedStackDiagTypes is the list of stack apps supported by elastic/support-diagnostics
+	supportedStackDiagTypes = []string{elasticsearchJob, kibanaJob, logstashJob}
+
 	//go:embed job.tpl.yml
 	jobTemplate string
 	// jobPollingInterval is used to configure the informer used to be notified of Pod status changes.
@@ -136,7 +140,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 		return err
 	}
 
-	diagnosticType, shortType := diagnosticTypeForApplication(typ)
+	diagnosticType, svcSuffix := diagnosticTypeForApplication(typ)
 
 	buffer := new(bytes.Buffer)
 	err = tpl.Execute(buffer, map[string]interface{}{
@@ -144,7 +148,7 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 		"DiagnosticImage":   ds.diagnosticImage,
 		"Namespace":         ds.ns,
 		"ESName":            esName,
-		"SVCName":           fmt.Sprintf("%s-%s-http", resourceName, shortType),
+		"SVCName":           fmt.Sprintf("%s-%s", resourceName, svcSuffix),
 		"Type":              diagnosticType,
 		"TLS":               tls,
 		"OutputDir":         podOutputDir,
@@ -198,14 +202,16 @@ func (ds *diagJobState) scheduleJob(typ, esName, resourceName string, tls bool) 
 	return nil
 }
 
-// diagnosticTypeForApplication returns the diagnosticType as expected by the stack diagnostics tool and a short type
-// matching the shorthand used by ECK in service names for the given application type.
+// diagnosticTypeForApplication returns the diagnosticType as expected by the stack diagnostics tool and the suffix
+// used by ECK in service names for the given application type.
 func diagnosticTypeForApplication(typ string) (string, string) {
 	switch typ {
 	case elasticsearchJob:
-		return "api", "es"
+		return "api", "es-http"
 	case kibanaJob:
-		return "kibana-api", "kb"
+		return "kibana-api", "kb-http"
+	case logstashJob:
+		return "logstash-api", "ls-api"
 	}
 	panic("programming error: unknown type")
 }
@@ -358,13 +364,11 @@ func (ds *diagJobState) detectImageErrors(pod *corev1.Pod) error {
 func runStackDiagnostics(k *Kubectl, ns string, zipFile *archive.ZipFile, verbose bool, image string, jobTimeout time.Duration, stopCh chan struct{}, filters internal_filters.Filters) {
 	state := newDiagJobState(k, ns, verbose, image, jobTimeout, stopCh)
 
-	if err := scheduleJobs(k, ns, zipFile.AddError, state, elasticsearchJob, filters); err != nil {
-		zipFile.AddError(err)
-		return
-	}
-	if err := scheduleJobs(k, ns, zipFile.AddError, state, kibanaJob, filters); err != nil {
-		zipFile.AddError(err)
-		return
+	for _, typ := range supportedStackDiagTypes {
+		if err := scheduleJobs(k, ns, zipFile.AddError, state, typ, filters); err != nil {
+			zipFile.AddError(err)
+			return
+		}
 	}
 	// don't start extracting if there is nothing to do
 	if len(state.jobs) == 0 {
@@ -379,44 +383,88 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 	if err != nil {
 		return err // not recoverable
 	}
-	return resources.Visit(func(info *resource.Info, err error) error {
+	return resources.Visit(func(ressourceInfo *resource.Info, err error) error {
 		if err != nil {
 			// record error but continue trying for other resources
 			recordErr(err)
 		}
 
-		resourceName := info.Name
-		es, err := runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
+		isTLS, esName, err := extractEsInfo(typ, ns, ressourceInfo, filters)
 		if err != nil {
 			recordErr(err)
-			return nil
 		}
-		disabled, found, err := unstructured.NestedBool(es, "spec", "http", "tls", "selfSignedCertificate", "disabled")
-		if err != nil {
-			recordErr(err)
-			return nil
+		if esName != "" {
+			logger.Print("scheduleJob", "typ ", typ, "es ", esName)
+			recordErr(state.scheduleJob(typ, esName, ressourceInfo.Name, isTLS))
 		}
-		tls := !(found && disabled)
-
-		if !filters.Empty() && !filters.Contains(resourceName, typ) {
-			return nil
-		}
-
-		esName := resourceName
-		if typ != "elasticsearch" {
-			val, found, err := unstructured.NestedString(es, "spec", "elasticsearchRef", "name")
-			if err != nil {
-				recordErr(err)
-				return nil
-			}
-			if !found || val == "" {
-				logger.Printf("Skipping %s/%s as it it not using elasticsearchRef", ns, resourceName)
-				return nil
-			}
-			esName = val
-		}
-
-		recordErr(state.scheduleJob(typ, esName, resourceName, tls))
 		return nil
 	})
+}
+
+func extractEsInfo(typ string, ns string, resourceInfo *resource.Info, filters internal_filters.Filters) (bool, string, error) {
+	resourceName := resourceInfo.Name
+
+	if !filters.Empty() && !filters.Contains(resourceName, typ) {
+		return false, "", nil
+	}
+
+	es, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resourceInfo.Object)
+	if err != nil {
+		return false, "", err
+	}
+
+	isTLS := false
+	switch typ {
+	case logstashJob:
+		// Logstash API SSL is not yet configurable via spec.http.tls, try to read the config as a best-effort
+		enabled, found, err := unstructured.NestedBool(es, "spec", "config", "api.ssl.enabled")
+		if err != nil {
+			return false, "", err
+		}
+		isTLS = found && enabled
+
+	default:
+		disabled, found, err := unstructured.NestedBool(es, "spec", "http", "tls", "selfSignedCertificate", "disabled")
+		if err != nil {
+			return false, "", err
+		}
+		isTLS = !(found && disabled)
+	}
+
+	var esName string
+	switch typ {
+	case elasticsearchJob:
+		esName = resourceName
+	case kibanaJob:
+		name, found, err := unstructured.NestedString(es, "spec", "elasticsearchRef", "name")
+		if err != nil {
+			return false, "", err
+		}
+		if !found || name == "" {
+			logger.Printf("Skipping %s/%s as elasticsearchRef is not defined", ns, resourceName)
+			return false, "", nil
+		}
+		esName = name
+	case logstashJob:
+		esRefs, found, err := unstructured.NestedSlice(es, "spec", "elasticsearchRefs")
+		if err != nil {
+			return false, "", err
+		}
+		if !found || len(esRefs) == 0 {
+			logger.Printf("Skipping %s/%s as elasticsearchRefs is not defined", ns, resourceName)
+			return false, "", nil
+		}
+		esRef := esRefs[0].(map[string]interface{})
+		name, found, err := unstructured.NestedString(esRef, "name")
+		if err != nil {
+			return false, "", err
+		}
+		if !found || name == "" {
+			logger.Printf("Skipping %s/%s as name is not set in elasticsearchRefs[0]", ns, resourceName)
+			return false, "", nil
+		}
+		esName = name
+	}
+
+	return isTLS, esName, nil
 }

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -383,23 +383,23 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 	if err != nil {
 		return err // not recoverable
 	}
-	return resources.Visit(func(ressourceInfo *resource.Info, err error) error {
+	return resources.Visit(func(resourceInfo *resource.Info, err error) error {
 		if err != nil {
 			// record error but continue trying for other resources
 			recordErr(err)
 		}
 
-		isTLS, esName, err := extractEsInfo(typ, ns, ressourceInfo)
+		isTLS, esName, err := extractEsInfo(typ, ns, resourceInfo)
 		if err != nil {
 			recordErr(err)
 		}
 
-		ressourceName := ressourceInfo.Name
-		if !filters.Empty() && !filters.Contains(ressourceName, typ) {
+		resourceName := resourceInfo.Name
+		if !filters.Empty() && !filters.Contains(resourceName, typ) {
 			return nil
 		}
 
-		recordErr(state.scheduleJob(typ, esName, ressourceName, isTLS))
+		recordErr(state.scheduleJob(typ, esName, resourceName, isTLS))
 		return nil
 	})
 }

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -417,6 +417,7 @@ func extractEsInfo(typ string, ns string, resourceInfo *resource.Info, filters i
 	switch typ {
 	case logstashJob:
 		// Logstash API SSL is not yet configurable via spec.http.tls, try to read the config as a best-effort
+		// To change after https://github.com/elastic/cloud-on-k8s/issues/6971 is fixed.
 		enabled, found, err := unstructured.NestedBool(es, "spec", "config", "api.ssl.enabled")
 		if err != nil {
 			return false, "", err

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -389,7 +389,7 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 			recordErr(err)
 		}
 
-		isTLS, esName, err := extractEsInfo(typ, ns, ressourceInfo, filters)
+		isTLS, esName, err := extractEsInfo(typ, ns, ressourceInfo)
 		if err != nil {
 			recordErr(err)
 		}
@@ -404,7 +404,7 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 	})
 }
 
-func extractEsInfo(typ string, ns string, resourceInfo *resource.Info, filters internal_filters.Filters) (bool, string, error) {
+func extractEsInfo(typ string, ns string, resourceInfo *resource.Info) (bool, string, error) {
 	resourceName := resourceInfo.Name
 
 	es, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resourceInfo.Object)


### PR DESCRIPTION
This adds support for getting `Logstash` resources and running [elastic/support-diagnostics](https://github.com/elastic/support-diagnostics) with `--type logstash-api` from ECK `2.8.0`.

Resolves #170.