### PR TITLE
Fix case where archive does not contain a top-level directory

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -35,7 +35,7 @@ func RootDir(name string) string {
 	}
 	// cover case where name is not a directory at all
 	if i == len(name) && name[0] != archivePathSeparator {
-		return ""
+		return string(archivePathSeparator)
 	}
 	return name[0:i]
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -28,9 +28,14 @@ func RootDir(name string) string {
 	if len(name) == 0 {
 		return name
 	}
+
 	i := 1
 	for i < len(name) && name[i] != archivePathSeparator {
 		i++
+	}
+	// cover case where name is not a directory at all
+	if i == len(name) && name[0] != archivePathSeparator {
+		return ""
 	}
 	return name[0:i]
 }

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -36,6 +36,13 @@ func Test_rootDir(t *testing.T) {
 			},
 			want: "/dir",
 		},
+		{
+			name: "not a dir",
+			args: args{
+				"version.txt",
+			},
+			want: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -41,7 +41,7 @@ func Test_rootDir(t *testing.T) {
 			args: args{
 				"version.txt",
 			},
-			want: "",
+			want: "/",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
While debugging ECK e2e test failures I noticed that elastic-agent diagnostics were broken because the diagnostics archive no longer contains a top level directory. This fix tries to address this.