### PR TITLE
Pin to last working version of go-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           BUILD_DATE: ${{ steps.get_build_date.outputs.BUILD_DATE }}
         with:
-          version: latest
+          version: v1.18.2
           args: release --rm-dist


### PR DESCRIPTION
It looks like releases are not working any more with the newer version of go-releaser. Before debugging why I thought it might be helpful to get to a working state again by going back to the version that still worked on the last release.