### PR TITLE
Update goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           BUILD_DATE: ${{ steps.get_build_date.outputs.BUILD_DATE }}
         with:
-          version: v1.18.2
+          version: latest
           args: release --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,12 +11,13 @@ builds:
       - darwin
     ldflags: -X github.com/elastic/eck-diagnostics/internal.buildVersion={{.Env.VERSION}} -X github.com/elastic/eck-diagnostics/internal.buildHash={{.ShortCommit}} -X github.com/elastic/eck-diagnostics/internal.buildDate={{.Env.BUILD_DATE}} -X github.com/elastic/eck-diagnostics/internal.snapshotBuild=false
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - NOTICE.txt
       - LICENSE


### PR DESCRIPTION
This updates the goreleaser config because `archives.replacements` are deprecated (https://goreleaser.com/deprecations/#archivesreplacements).