### PR TITLE
Enable image push to distribute binaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,29 +1,29 @@
 
 env:
-  DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-cloud-on-k8s/docker-registry-elastic
-  DOCKER_REGISTRY_HOSTNAME: docker.elastic.co
+  DOCKER_REGISTRY_VAULT_PATH: secret/ci/elastic-eck-diagnostics/docker-registry-elastic
 
 steps:
 
-  - label: "lint"
+  - label: ":go: lint"
     command: make lint
     agents:
-      image: "golang:1.21.1"
+      image: "golang:1.21.4"
       cpu: "4"
       memory: "8G"
 
-  - label: "test"
+  - label: ":go: tests"
     command: make unit-tests
     agents:
-      image: "golang:1.21.1"
+      image: "golang:1.21.4"
       cpu: "4"
       memory: "4G"
 
-  - label: "publish-image"
+  - wait
+
+  - label: ":docker: build"
     commands:
-      #- .buildkite/registry-login.sh
-      #- drivah build --push .
-      - drivah build .
+      - .buildkite/registry-login.sh
+      - drivah build --push .
     agents:
       image: "docker.elastic.co/ci-agent-images/drivah:0.24.3"
       cpu: "4"

--- a/.buildkite/registry-login.sh
+++ b/.buildkite/registry-login.sh
@@ -6,7 +6,6 @@
 
 set -eu
 
-username=$(vault read -field=username "$DOCKER_REGISTRY_VAULT_PATH")
-password=$(vault read -field=password "$DOCKER_REGISTRY_VAULT_PATH")
+get() { vault read -field="$1" "$DOCKER_REGISTRY_VAULT_PATH"; }
 
-buildah login --username="${username}" --password="${password}" "$DOCKER_REGISTRY_HOSTNAME"
+buildah login --username="$(get username)" --password="$(get password)" "$(get hostname)"


### PR DESCRIPTION
This commit uses the correct vault path to get docker registry creds and enables `--push` when building image via drivah.