### PR TITLE
Do not run Logstash diag. tool on ECK before version 2.8.0

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -208,7 +208,7 @@ LOOP:
 				"elasticmapsserver",
 			}))
 		}
-		if maxOperatorVersion.AtLeast(version.MustParseSemantic("2.8.0")) {
+		if maxOperatorVersion.AtLeast(logstashMinVersion) {
 			zipFile.Add(getResources(kubectl.GetByName, ns, namespaceFilters, []string{
 				"logstash",
 			}))
@@ -223,7 +223,17 @@ LOOP:
 		getLogs(kubectl, zipFile, ns, namespaceFilters, logsLabels...)
 
 		if params.RunStackDiagnostics {
-			runStackDiagnostics(kubectl, ns, zipFile, params.Verbose, params.DiagnosticImage, params.StackDiagnosticsTimeout, stopCh, namespaceFilters)
+			runStackDiagnostics(
+				kubectl,
+				ns,
+				zipFile,
+				params.Verbose,
+				params.DiagnosticImage,
+				params.StackDiagnosticsTimeout,
+				stopCh,
+				namespaceFilters,
+				maxOperatorVersion,
+			)
 		}
 
 		if params.RunAgentDiagnostics {

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -15,12 +15,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/elastic/eck-diagnostics/internal/archive"
-	"github.com/elastic/eck-diagnostics/internal/extraction"
-	internal_filters "github.com/elastic/eck-diagnostics/internal/filters"
 	"github.com/ghodss/yaml"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,11 +26,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubectl/pkg/util/podutils"
 	"k8s.io/utils/ptr"
+
+	"github.com/elastic/eck-diagnostics/internal/archive"
+	"github.com/elastic/eck-diagnostics/internal/extraction"
+	internal_filters "github.com/elastic/eck-diagnostics/internal/filters"
 )
 
 const (
@@ -48,14 +51,23 @@ const (
 )
 
 var (
-	// supportedStackDiagTypes is the list of stack apps supported by elastic/support-diagnostics
-	supportedStackDiagTypes = []string{elasticsearchJob, kibanaJob, logstashJob}
-
 	//go:embed job.tpl.yml
 	jobTemplate string
 	// jobPollingInterval is used to configure the informer used to be notified of Pod status changes.
 	jobPollingInterval = 10 * time.Second
+
+	// logstashMinVersion is the ECK version in which Logstash support has been introduced.
+	logstashMinVersion = version.MustParseSemantic("2.8.0")
 )
+
+// supportedStackDiagTypes returns the list of stack apps supported by elastic/support-diagnostics.
+func supportedStackDiagTypesFor(eckVersion *version.Version) []string {
+	supportedStackDiagTypes := []string{elasticsearchJob, kibanaJob}
+	if eckVersion.AtLeast(logstashMinVersion) {
+		supportedStackDiagTypes = append(supportedStackDiagTypes, logstashJob)
+	}
+	return supportedStackDiagTypes
+}
 
 // diagJob represents a pod whose job it is to extract diagnostic data from an Elasticsearch cluster.
 type diagJob struct {
@@ -361,10 +373,19 @@ func (ds *diagJobState) detectImageErrors(pod *corev1.Pod) error {
 
 // runStackDiagnostics extracts diagnostic data from all clusters in the given namespace ns using the official
 // Elasticsearch support diagnostics.
-func runStackDiagnostics(k *Kubectl, ns string, zipFile *archive.ZipFile, verbose bool, image string, jobTimeout time.Duration, stopCh chan struct{}, filters internal_filters.Filters) {
+func runStackDiagnostics(
+	k *Kubectl, ns string,
+	zipFile *archive.ZipFile,
+	verbose bool,
+	image string,
+	jobTimeout time.Duration,
+	stopCh chan struct{},
+	filters internal_filters.Filters,
+	eckVersion *version.Version,
+) {
 	state := newDiagJobState(k, ns, verbose, image, jobTimeout, stopCh)
 
-	for _, typ := range supportedStackDiagTypes {
+	for _, typ := range supportedStackDiagTypesFor(eckVersion) {
 		if err := scheduleJobs(k, ns, zipFile.AddError, state, typ, filters); err != nil {
 			zipFile.AddError(err)
 			return

--- a/internal/stackdiag_test.go
+++ b/internal/stackdiag_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	_ "embed"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+func Test_supportedStackDiagTypesFor(t *testing.T) {
+	type args struct {
+		eckVersion *version.Version
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "before 2.8",
+			args: args{eckVersion: version.MustParseSemantic("2.7.99")},
+			want: []string{"elasticsearch", "kibana"},
+		},
+		{
+			name: "after 2.8",
+			args: args{eckVersion: version.MustParseSemantic("2.8.0")},
+			want: []string{"elasticsearch", "kibana", "logstash"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := supportedStackDiagTypesFor(tt.args.eckVersion); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("supportedStackDiagTypesFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR prevents the diagnostic tool from running a Logstash diagnostic Pod if the CRD is not available. 