### PR TITLE
Update stack-diagnostics to 9.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage:
   eck-diagnostics [flags]
 
 Flags:
-      --diagnostic-image string              Diagnostic image to be used for stack diagnostics, see run-stack-diagnostics (default "docker.elastic.co/eck-dev/support-diagnostics:8.5.0")
+      --diagnostic-image string              Diagnostic image to be used for stack diagnostics, see run-stack-diagnostics (default "docker.elastic.co/eck-dev/support-diagnostics:9.1.0")
       --eck-version string                   ECK version in use, will try to autodetect if not specified
   -f, --filters strings                      Comma-separated list of filters in format "type=name". Example: elasticsearch=my-cluster (Supported types [agent apm beat elasticsearch enterprisesearch kibana maps logstash])
   -h, --help                                 help for eck-diagnostics

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:8.5.0"
+	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:9.1.0"
 
 	podOutputDir         = "/diagnostic-output"
 	podMainContainerName = "stack-diagnostics"


### PR DESCRIPTION
This updates stack diagnostics to the latest version. We hope to get an official image from support soon, so hopefully this is the last time we need to built one for ECK separately.