### PR TITLE
Default diagnostics image to 9.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage:
   eck-diagnostics [flags]
 
 Flags:
-      --diagnostic-image string              Diagnostic image to be used for stack diagnostics, see run-stack-diagnostics (default "docker.elastic.co/eck-dev/support-diagnostics:9.1.0")
+      --diagnostic-image string              Diagnostic image to be used for stack diagnostics, see run-stack-diagnostics (default "docker.elastic.co/eck-dev/support-diagnostics:9.3.1")
       --eck-version string                   ECK version in use, will try to autodetect if not specified
   -f, --filters strings                      Comma-separated list of filters in format "type=name". Example: elasticsearch=my-cluster (Supported types [agent apm beat elasticsearch enterprisesearch kibana maps logstash])
   -h, --help                                 help for eck-diagnostics

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:9.1.0"
+	DiagnosticImage = "docker.elastic.co/eck-dev/support-diagnostics:9.3.1"
 
 	podOutputDir         = "/diagnostic-output"
 	podMainContainerName = "stack-diagnostics"


### PR DESCRIPTION
In preparation for a release of the eck-diagnostics tool this upgrades the default value to the [latest released version](https://github.com/elastic/support-diagnostics/releases/tag/v9.3.1) of support-diagnostics. 