### PR TITLE
Run stack support diagnostics pod with more restrictive security context.

### DIFF
--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -13,8 +13,14 @@ spec:
       image: {{ .DiagnosticImage }}
       imagePullPolicy: IfNotPresent
       securityContext:
-        runAsUser: 1000
+        runAsNonRoot: true
         allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        seccompProfile:
+          type: RuntimeDefault
       {{ if (and .ESSecretName .ESSecretKey) }}
       env:
         - name: ES_PW


### PR DESCRIPTION
Fixes #349 

This should make it easier to run eck-diagnostics on secure Kubernetes clusters. 

