### PR TITLE
add stackconfigpolicy to eck-diagnostics

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -220,6 +220,12 @@ LOOP:
 			}))
 		}
 
+		if maxOperatorVersion.AtLeast(stackConfigPolicyMinVersion) {
+			zipFile.Add(getResources(kubectl.GetByName, ns, namespaceFilters, []string{
+				"stackconfigpolicy",
+			}))
+		}
+
 		zipFile.Add(map[string]func(io.Writer) error{
 			archive.Path(ns, "secrets.json"): func(writer io.Writer) error {
 				return kubectl.GetMeta("secrets", ns, writer)

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -60,6 +60,9 @@ var (
 
 	// logstashMinVersion is the ECK version in which Logstash support has been introduced.
 	logstashMinVersion = version.MustParseSemantic("2.8.0")
+
+	// stackConfigPolicyMinVersion is the ECK version in which StackConfigPolicy support has been introduced.
+	stackConfigPolicyMinVersion = version.MustParseSemantic("2.6.0")
 )
 
 // supportedStackDiagTypes returns the list of stack apps supported by elastic/support-diagnostics.


### PR DESCRIPTION
## What does this PR do?

This PR ensures that any `StackConfigPolicy` resources present in the monitored namespaces are discovered and included in the eck-diagnostics output bundle. 

## Why is it important?

- `StackConfigPolicy` enables operators to enforce consistent configuration, user/role definitions, and security policies across multiple Elastic Stack deployments.
- When troubleshooting ECK-managed clusters, it is important to have complete visibility into all policies that may influence component behavior or access control.
- Collecting these central policy resources in diagnostics accelerates support workflows and enables more accurate, reliable issue analysis.

## Implementation details

The resource collection logic is enhanced to detect and export all `StackConfigPolicy` CRDs in the selected namespaces.

## Related issues

- N/A