### PR TITLE
Add version field and schema link

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
https://github.com/elastic/eck-diagnostics/actions/runs/21679849146/job/62510770369

```
  • only version: 2 configuration files are supported, yours is version: 0, please update your configuration
```

This simply adds the `version` field to stop this warning, and adds a schema link to assist with ide validation.