### PR TITLE
Fix AutoOps agent log label selector

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -141,7 +141,7 @@ func Run(params Params) error {
 		"common.k8s.elastic.co/type=agent",                  // 1.4.0
 		"common.k8s.elastic.co/type=maps",                   // 1.6.0
 		"common.k8s.elastic.co/type=logstash",               // 2.8.0
-		"common.k8s.elastic.co/type=autoopsagentpolicy",     // 3.3.0
+		"common.k8s.elastic.co/type=autoops-agent",          // 3.3.0
 		"common.k8s.elastic.co/type=elasticpackageregistry", // 3.3.0
 	}
 


### PR DESCRIPTION
## Summary

- Fixes the log collection label selector for AutoOps agents: the pods use `common.k8s.elastic.co/type=autoops-agent` but the selector had `autoopsagentpolicy` (the CRD name), so AutoOps agent pod logs were never collected.

Fixes #378

## Test plan

- [x] Verified against a cluster with AutoOps agents running in the `observability` namespace
- [x] Confirmed AutoOps agent pod logs now appear in the diagnostic archive under `{ns}/pod/quickstart-autoops-deploy-*/logs.txt`
- [x] Confirmed existing resources (AutoOpsAgentPolicy CRD, ConfigMaps, secrets metadata, pod specs) continue to be collected as before
