### PR TITLE
Add --keep-secret-data flag to preserve secret data in diagnostics

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 	cmd.Flags().DurationVar(&diagParams.AgentDiagnosticsTimeout, "agent-diagnostics-timeout", 5*time.Minute, "Maximum time to wait for each Elastic Agent diagnostic to complete")
 	cmd.Flags().IntVar(&diagParams.AgentDiagnosticsConcurrency, "agent-diagnostics-concurrency", 5, "Maximum number of concurrent Elastic Agent diagnostics to run")
 	cmd.Flags().StringSliceVar(&diagParams.ImagePullSecrets, "image-pull-secrets", nil, "Comma-separated list of Kubernetes secret names to use as imagePullSecrets for diagnostic Pods")
-	cmd.Flags().BoolVar(&diagParams.KeepSecretData, "keep-secret-data", false, "Keep secret data in the diagnostics archive. Warning: credentials will not be redacted and appear as plain text")
+	cmd.Flags().BoolVar(&diagParams.KeepSecretData, "keep-secret-data", false, "Keep secret data in the diagnostics archive. Warning: credentials will not be redacted and appear as plain text in the archive")
 
 	if err := cmd.MarkFlagRequired(resourcesNamespaces); err != nil {
 		exitWithError(err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,6 +55,7 @@ func main() {
 	cmd.Flags().DurationVar(&diagParams.AgentDiagnosticsTimeout, "agent-diagnostics-timeout", 5*time.Minute, "Maximum time to wait for each Elastic Agent diagnostic to complete")
 	cmd.Flags().IntVar(&diagParams.AgentDiagnosticsConcurrency, "agent-diagnostics-concurrency", 5, "Maximum number of concurrent Elastic Agent diagnostics to run")
 	cmd.Flags().StringSliceVar(&diagParams.ImagePullSecrets, "image-pull-secrets", nil, "Comma-separated list of Kubernetes secret names to use as imagePullSecrets for diagnostic Pods")
+	cmd.Flags().BoolVar(&diagParams.KeepSecretData, "keep-secret-data", false, "Keep secret data in the diagnostics archive. Warning: credentials will not be redacted and appear as plain text")
 
 	if err := cmd.MarkFlagRequired(resourcesNamespaces); err != nil {
 		exitWithError(err)

--- a/internal/diag.go
+++ b/internal/diag.go
@@ -65,6 +65,9 @@ func (dp Params) AllNamespaces() []string {
 // It produces a zip file with the contents as a side effect.
 func Run(params Params) error {
 	logger.Printf("ECK diagnostics with parameters: %+v", params)
+	if params.KeepSecretData {
+		logger.Printf("WARNING: --keep-secret-data is enabled. Secret data will NOT be redacted and may appear as plain text in the archive.")
+	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 

--- a/internal/diag.go
+++ b/internal/diag.go
@@ -48,6 +48,7 @@ type Params struct {
 	AgentDiagnosticsTimeout     time.Duration
 	AgentDiagnosticsConcurrency int
 	ImagePullSecrets            []string
+	KeepSecretData              bool
 	Filters                     filters.Filters
 	LogFilters                  filters.Filters
 }
@@ -236,7 +237,7 @@ LOOP:
 
 		zipFile.Add(map[string]func(io.Writer) error{
 			archive.Path(ns, "secrets.json"): func(writer io.Writer) error {
-				return kubectl.GetMeta("secrets", ns, writer)
+				return kubectl.GetMeta("secrets", ns, params.KeepSecretData, writer)
 			},
 		})
 

--- a/internal/kubectl.go
+++ b/internal/kubectl.go
@@ -305,7 +305,8 @@ func (c Kubectl) getResourcesMatching(resource string, namespace string, selecto
 
 // GetMeta retrieves the metadata for the K8s objects of type resource and marshals them into writer w.
 // It tries to elide sensitive data like secret contents or kubectl last-applied configuration annotations.
-func (c Kubectl) GetMeta(resource, namespace string, w io.Writer) error {
+// If keepSecretData is true, secret data will be preserved in the output.
+func (c Kubectl) GetMeta(resource, namespace string, keepSecretData bool, w io.Writer) error {
 	r := c.factory.NewBuilder().
 		Unstructured().
 		NamespaceParam(namespace).DefaultNamespace().AllNamespaces(false).
@@ -345,8 +346,10 @@ func (c Kubectl) GetMeta(resource, namespace string, w io.Writer) error {
 		if err != nil {
 			return err
 		}
-		// remove the actual secret data
-		delete(unstructured, "data")
+		if !keepSecretData {
+			// remove the actual secret data
+			delete(unstructured, "data")
+		}
 		// or spec for other objects
 		delete(unstructured, "spec")
 		metas.Items = append(metas.Items, unstructured)

--- a/internal/kubectl.go
+++ b/internal/kubectl.go
@@ -350,7 +350,7 @@ func (c Kubectl) GetMeta(resource, namespace string, keepSecretData bool, w io.W
 			// remove the actual secret data
 			delete(unstructured, "data")
 		}
-		// or spec for other objects
+		// always remove spec for other objects
 		delete(unstructured, "spec")
 		metas.Items = append(metas.Items, unstructured)
 	}

--- a/internal/kubectl_test.go
+++ b/internal/kubectl_test.go
@@ -1,0 +1,189 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestGetMeta(t *testing.T) {
+	tests := []struct {
+		name           string
+		objects        []runtime.Object
+		keepSecretData bool
+		wantDataField  bool
+	}{
+		{
+			name: "single secret data redacted when keepSecretData is false",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "default", Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "sensitive-config-data"}},
+					Data:       map[string][]byte{"password": []byte("supersecret")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+			},
+			keepSecretData: false,
+			wantDataField:  false,
+		},
+		{
+			name: "single secret data preserved when keepSecretData is true",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-secret", Namespace: "default", Annotations: map[string]string{corev1.LastAppliedConfigAnnotation: "sensitive-config-data"}},
+					Data:       map[string][]byte{"password": []byte("supersecret")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+			},
+			keepSecretData: true,
+			wantDataField:  true,
+		},
+		{
+			name: "multiple secrets redacted when keepSecretData is false",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-1", Namespace: "default"},
+					Data:       map[string][]byte{"key1": []byte("value1")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-2", Namespace: "default"},
+					Data:       map[string][]byte{"key2": []byte("value2")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+			},
+			keepSecretData: false,
+			wantDataField:  false,
+		},
+		{
+			name: "multiple secrets preserved when keepSecretData is true",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-1", Namespace: "default"},
+					Data:       map[string][]byte{"key1": []byte("value1")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "secret-2", Namespace: "default"},
+					Data:       map[string][]byte{"key2": []byte("value2")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+			},
+			keepSecretData: true,
+			wantDataField:  true,
+		},
+		{
+			name: "pod spec is removed",
+			objects: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "main", Image: "nginx:latest"},
+						},
+					},
+				},
+			},
+			keepSecretData: false,
+			wantDataField:  false,
+		},
+		{
+			name: "mixed secrets and pods",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-secret", Namespace: "default"},
+					Data:       map[string][]byte{"token": []byte("secret-token")},
+					Type:       corev1.SecretTypeOpaque,
+				},
+				&corev1.Pod{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+					ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "app", Image: "myapp:v1"},
+						},
+					},
+				},
+			},
+			keepSecretData: false,
+			wantDataField:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			list := &corev1.List{}
+			for _, obj := range tt.objects {
+				raw, err := runtime.Encode(scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion), obj)
+				require.NoError(t, err, "failed to encode object")
+				list.Items = append(list.Items, runtime.RawExtension{Raw: raw})
+			}
+
+			tf := cmdtesting.NewTestFactory().WithNamespace("default")
+			defer tf.Cleanup()
+
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+			tf.UnstructuredClient = &fake.RESTClient{
+				NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+				Resp: &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     cmdtesting.DefaultHeader(),
+					Body:       cmdtesting.ObjBody(codec, list),
+				},
+			}
+
+			kubectl := &Kubectl{
+				factory: tf,
+			}
+
+			var buf bytes.Buffer
+			err := kubectl.GetMeta("secrets", "default", tt.keepSecretData, &buf)
+			require.NoError(t, err, "GetMeta() should not return an error")
+
+			var result struct {
+				Items []map[string]interface{} `json:"Items"`
+			}
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &result), "failed to unmarshal result")
+			require.Len(t, result.Items, len(tt.objects))
+
+			for i, item := range result.Items {
+				_, hasData := item["data"]
+				assert.Equalf(t, tt.wantDataField, hasData, "item[%d]: data field presence mismatch", i)
+
+				_, hasSpec := item["spec"]
+				assert.Falsef(t, hasSpec, "item[%d]: spec field should always be removed", i)
+
+				metadata, ok := item["metadata"].(map[string]interface{})
+				require.Truef(t, ok, "item[%d]: metadata should be present and be a map", i)
+
+				annotations, _ := metadata["annotations"].(map[string]interface{})
+				if annotations != nil {
+					_, hasLastApplied := annotations[corev1.LastAppliedConfigAnnotation]
+					assert.Falsef(t, hasLastApplied, "item[%d]: last-applied-configuration annotation should be removed", i)
+				}
+			}
+		})
+	}
+}

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -117,12 +117,12 @@ func (d *diagJob) MarkDone() {
 
 // diagJobState captures the state of running a set of jobs to extract diagnostics from Elastic Stack applications.
 type diagJobState struct {
-	ns              string
-	kubectl         *Kubectl
-	informer        cache.SharedInformer
-	jobs            map[string]*diagJob
-	context         context.Context
-	cancelFunc      context.CancelFunc
+	ns               string
+	kubectl          *Kubectl
+	informer         cache.SharedInformer
+	jobs             map[string]*diagJob
+	context          context.Context
+	cancelFunc       context.CancelFunc
 	verbose          bool
 	diagnosticImage  string
 	jobTimeout       time.Duration
@@ -140,13 +140,13 @@ func newDiagJobState(ctx context.Context, k *Kubectl, ns string, verbose bool, i
 			options.LabelSelector = "app.kubernetes.io/name=eck-diagnostics"
 		}))
 	state := &diagJobState{
-		jobs:            map[string]*diagJob{},
-		ns:              ns,
-		kubectl:         k,
-		informer:        factory.Core().V1().Pods().Informer(),
-		cancelFunc:      cancelFunc,
-		context:         ctx,
-		verbose:         verbose,
+		jobs:             map[string]*diagJob{},
+		ns:               ns,
+		kubectl:          k,
+		informer:         factory.Core().V1().Pods().Informer(),
+		cancelFunc:       cancelFunc,
+		context:          ctx,
+		verbose:          verbose,
 		diagnosticImage:  image,
 		jobTimeout:       jobTimeout,
 		imagePullSecrets: imagePullSecrets,


### PR DESCRIPTION
## Summary

Adds a new `--keep-secret-data` flag that preserves secret data in the diagnostics archive instead of redacting it.

## Motivation

In certain scenarios, such as debugging CI e2e test failures in the cloud-on-k8s repo, having access to the actual secret data can be essential for troubleshooting. Currently, all secret data is redacted by default, which can make it difficult to diagnose issues related to credentials or configuration stored in secrets.

## Usage

```bash
eck-diagnostics -r my-namespace --keep-secret-data
```

## Safety

This flag is **disabled by default** (`false`) because including unredacted secrets in diagnostic archives poses a security risk. Users must explicitly opt-in by passing `--keep-secret-data`.

A warning is included in the flag description to alert users that credentials will appear as plain text in the archive.