### PR TITLE
Support diagnostics on mTLS-enabled Elasticsearch clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/kubectl v0.36.0
 	k8s.io/streaming v0.36.0
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
+	software.sslmate.com/src/go-pkcs12 v0.7.1
 )
 
 require (
@@ -56,6 +57,7 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
+golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
@@ -199,3 +201,5 @@ sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+software.sslmate.com/src/go-pkcs12 v0.7.1 h1:bxkUPRsvTPNRBZa4M/aSX4PyMOEbq3V8I6hbkG4F4Q8=
+software.sslmate.com/src/go-pkcs12 v0.7.1/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/internal/clientcert.go
+++ b/internal/clientcert.go
@@ -104,7 +104,9 @@ func parsePrivateKey(der []byte) (any, error) {
 // createKeystoreSecret builds a PKCS12 keystore from certPEM/keyPEM and stores it together with
 // a freshly-generated password in a per-job Secret named <podName>-keystore. Any pre-existing
 // Secret with the same name is replaced. The returned name is suitable for mounting into the
-// diagnostic Pod.
+// diagnostic Pod. The password is a PKCS12 format requirement (the format mandates password-based
+// encryption); it adds no confidentiality beyond what Kubernetes Secret access control already
+// provides - anyone who can read the Secret can read both the keystore and its password.
 func createKeystoreSecret(ctx context.Context, k *Kubectl, ns, podName string, certPEM, keyPEM []byte) (string, error) {
 	pwBytes := make([]byte, 16)
 	if _, err := rand.Read(pwBytes); err != nil {

--- a/internal/clientcert.go
+++ b/internal/clientcert.go
@@ -133,8 +133,8 @@ func createKeystoreSecret(ctx context.Context, k *Kubectl, ns, podName string, c
 		},
 	}
 
-	if err := k.CoreV1().Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil && !apierrors.IsNotFound(err) {
-		return "", fmt.Errorf("deleting stale keystore secret %s/%s: %w", ns, secretName, err)
+	if err := deleteKeystoreSecret(ctx, k, ns, secretName); err != nil {
+		return "", err
 	}
 	if _, err := k.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
 		return "", fmt.Errorf("creating keystore secret %s/%s: %w", ns, secretName, err)

--- a/internal/clientcert.go
+++ b/internal/clientcert.go
@@ -1,0 +1,154 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+
+	"software.sslmate.com/src/go-pkcs12"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// clientCertSecretSuffix matches cloud-on-k8s OperatorClientCertSecretName layout for the ES namer:
+	// "<esName>-es-internal-client-cert".
+	clientCertSecretSuffix = "-es-internal-client-cert" //nolint:gosec // G101 false positive: secret name suffix, not a credential
+
+	// clientCertFile / clientKeyFile match cloud-on-k8s certificates.CertFileName / KeyFileName.
+	clientCertFile = "tls.crt"
+	clientKeyFile  = "tls.key"
+
+	// keystoreFile is the PKCS12 entry name inside the per-job Secret mounted into the diagnostic Pod.
+	keystoreFile = "keystore.p12"
+	// keystorePasswordKey is the Secret key holding the PKCS12 password.
+	keystorePasswordKey = "password"
+	// keystoreMountPath is where the per-job Secret is mounted inside the diagnostic Pod.
+	keystoreMountPath = "/client-cert"
+	// keystoreSecretSuffix is appended to the diagnostic Pod name to derive the per-job keystore Secret name.
+	keystoreSecretSuffix = "-keystore"
+)
+
+// loadOperatorClientCert returns the PEM-encoded client cert and key from the operator-managed
+// secret <esName>-es-internal-client-cert if it exists. Returns (nil, nil, false, nil) if the
+// secret does not exist (i.e. mTLS is not configured). This mirrors the lookup performed by
+// cloud-on-k8s certificates.LoadOperatorClientCertIfExists.
+func loadOperatorClientCert(k *Kubectl, ns, esName string) (certPEM, keyPEM []byte, found bool, err error) {
+	secretName := esName + clientCertSecretSuffix
+	secret, err := k.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, fmt.Errorf("getting client cert secret %s/%s: %w", ns, secretName, err)
+	}
+	cert, ok := secret.Data[clientCertFile]
+	if !ok || len(cert) == 0 {
+		return nil, nil, false, fmt.Errorf("missing %s in secret %s/%s", clientCertFile, ns, secretName)
+	}
+	key, ok := secret.Data[clientKeyFile]
+	if !ok || len(key) == 0 {
+		return nil, nil, false, fmt.Errorf("missing %s in secret %s/%s", clientKeyFile, ns, secretName)
+	}
+	return cert, key, true, nil
+}
+
+// buildPKCS12 produces a PKCS12 keystore protected by password from the given PEM-encoded
+// certificate and private key.
+func buildPKCS12(certPEM, keyPEM []byte, password string) ([]byte, error) {
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return nil, fmt.Errorf("decoding certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("decoding private key PEM")
+	}
+	priv, err := parsePrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key: %w", err)
+	}
+
+	return pkcs12.Modern.Encode(priv, cert, nil, password)
+}
+
+// parsePrivateKey accepts PKCS#8, PKCS#1 (RSA) or SEC1 (EC) DER-encoded keys.
+func parsePrivateKey(der []byte) (any, error) {
+	if k, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return k, nil
+	}
+	if k, err := x509.ParseECPrivateKey(der); err == nil {
+		return k, nil
+	}
+	return nil, fmt.Errorf("unsupported private key format")
+}
+
+// createKeystoreSecret builds a PKCS12 keystore from certPEM/keyPEM and stores it together with
+// a freshly-generated password in a per-job Secret named <podName>-keystore. Any pre-existing
+// Secret with the same name is replaced. The returned name is suitable for mounting into the
+// diagnostic Pod.
+func createKeystoreSecret(ctx context.Context, k *Kubectl, ns, podName string, certPEM, keyPEM []byte) (string, error) {
+	pwBytes := make([]byte, 16)
+	if _, err := rand.Read(pwBytes); err != nil {
+		return "", fmt.Errorf("generating keystore password: %w", err)
+	}
+	password := hex.EncodeToString(pwBytes)
+
+	p12, err := buildPKCS12(certPEM, keyPEM, password)
+	if err != nil {
+		return "", fmt.Errorf("building keystore: %w", err)
+	}
+
+	secretName := podName + keystoreSecretSuffix
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "eck-diagnostics",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			keystoreFile:        p12,
+			keystorePasswordKey: []byte(password),
+		},
+	}
+
+	if err := k.CoreV1().Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil && !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("deleting stale keystore secret %s/%s: %w", ns, secretName, err)
+	}
+	if _, err := k.CoreV1().Secrets(ns).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		return "", fmt.Errorf("creating keystore secret %s/%s: %w", ns, secretName, err)
+	}
+	return secretName, nil
+}
+
+// deleteKeystoreSecret deletes the per-job keystore secret if it exists. Not-found errors are ignored.
+func deleteKeystoreSecret(ctx context.Context, k *Kubectl, ns, secretName string) error {
+	if secretName == "" {
+		return nil
+	}
+	if err := k.CoreV1().Secrets(ns).Delete(ctx, secretName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting keystore secret %s/%s: %w", ns, secretName, err)
+	}
+	return nil
+}

--- a/internal/clientcert_test.go
+++ b/internal/clientcert_test.go
@@ -1,0 +1,187 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	_ "embed"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/ghodss/yaml"
+	corev1 "k8s.io/api/core/v1"
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
+)
+
+// generateTestCertPEM creates a self-signed ECDSA certificate suitable for round-tripping through
+// buildPKCS12 in tests. It returns PEM-encoded cert and PKCS#8 key.
+func generateTestCertPEM(t *testing.T) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "eck-internal"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("creating cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func Test_buildPKCS12_RoundTrip(t *testing.T) {
+	certPEM, keyPEM := generateTestCertPEM(t)
+	const password = "s3cret"
+
+	p12, err := buildPKCS12(certPEM, keyPEM, password)
+	if err != nil {
+		t.Fatalf("buildPKCS12: %v", err)
+	}
+	if len(p12) == 0 {
+		t.Fatal("buildPKCS12 returned empty bytes")
+	}
+
+	priv, cert, _, err := pkcs12.DecodeChain(p12, password)
+	if err != nil {
+		t.Fatalf("decoding p12: %v", err)
+	}
+	if priv == nil || cert == nil {
+		t.Fatalf("decoded p12 missing key or cert: priv=%v cert=%v", priv, cert)
+	}
+	if cert.Subject.CommonName != "eck-internal" {
+		t.Errorf("unexpected CN: %s", cert.Subject.CommonName)
+	}
+}
+
+func Test_buildPKCS12_RejectsBadPEM(t *testing.T) {
+	if _, err := buildPKCS12([]byte("not a pem"), []byte("not a pem"), "x"); err == nil {
+		t.Fatal("expected error for invalid PEM, got nil")
+	}
+}
+
+func Test_jobTemplate_keystore(t *testing.T) {
+	tests := []struct {
+		name               string
+		keystoreSecretName string
+		wantVolume         bool
+		wantArg            string
+	}{
+		{
+			name:               "no keystore: no volume, no pkiKeystore arg",
+			keystoreSecretName: "",
+			wantVolume:         false,
+			wantArg:            "--pkiKeystore",
+		},
+		{ //nolint:gosec // G101 false positive: test fixture, not a credential
+			name:               "with keystore: volume mounted and arg present",
+			keystoreSecretName: "test-es-elasticsearch-diag-keystore",
+			wantVolume:         true,
+			wantArg:            "--pkiKeystore /client-cert/keystore.p12 --pkiPassText $KEYSTORE_PW",
+		},
+	}
+
+	tpl, err := template.New("job").Parse(jobTemplate)
+	if err != nil {
+		t.Fatalf("parsing template: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := map[string]interface{}{
+				"PodName":             "test-pod",
+				"DiagnosticImage":     "docker.elastic.co/eck-dev/support-diagnostics:latest",
+				"Namespace":           "default",
+				"ESSecretName":        "es-secret",
+				"ESSecretKey":         "elastic",
+				"SVCName":             "elasticsearch-es-http",
+				"Type":                "api",
+				"TLS":                 true,
+				"OutputDir":           "/diagnostic-output",
+				"MainContainerName":   "stack-diagnostics",
+				"KeystoreSecretName":  tt.keystoreSecretName,
+				"KeystoreFile":        "keystore.p12",
+				"KeystorePasswordKey": "password",
+				"KeystoreMountPath":   "/client-cert",
+			}
+
+			buf := new(bytes.Buffer)
+			if err := tpl.Execute(buf, data); err != nil {
+				t.Fatalf("executing template: %v", err)
+			}
+			var pod corev1.Pod
+			if err := yaml.Unmarshal(buf.Bytes(), &pod); err != nil {
+				t.Fatalf("unmarshaling pod: %v\nrendered:\n%s", err, buf.String())
+			}
+
+			hasVolume := false
+			for _, v := range pod.Spec.Volumes {
+				if v.Name == "client-cert" {
+					hasVolume = true
+					if v.Secret == nil || v.Secret.SecretName != tt.keystoreSecretName {
+						t.Errorf("client-cert volume has wrong secret: %+v", v.Secret)
+					}
+				}
+			}
+			if hasVolume != tt.wantVolume {
+				t.Errorf("client-cert volume present = %v, want %v\nrendered:\n%s", hasVolume, tt.wantVolume, buf.String())
+			}
+
+			hasMount := false
+			hasEnv := false
+			for _, c := range pod.Spec.Containers {
+				for _, m := range c.VolumeMounts {
+					if m.Name == "client-cert" {
+						hasMount = true
+					}
+				}
+				for _, e := range c.Env {
+					if e.Name == "KEYSTORE_PW" {
+						hasEnv = true
+					}
+				}
+			}
+			if hasMount != tt.wantVolume {
+				t.Errorf("client-cert mount present = %v, want %v", hasMount, tt.wantVolume)
+			}
+			if hasEnv != tt.wantVolume {
+				t.Errorf("KEYSTORE_PW env present = %v, want %v", hasEnv, tt.wantVolume)
+			}
+
+			gotArgs := strings.Join(pod.Spec.Containers[0].Args, " ")
+			if tt.wantVolume {
+				if !strings.Contains(gotArgs, tt.wantArg) {
+					t.Errorf("expected args to contain %q, got: %s", tt.wantArg, gotArgs)
+				}
+			} else {
+				if strings.Contains(gotArgs, tt.wantArg) {
+					t.Errorf("expected args NOT to contain %q, got: %s", tt.wantArg, gotArgs)
+				}
+			}
+		})
+	}
+}

--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -27,17 +27,31 @@ spec:
         readOnlyRootFilesystem: true
         seccompProfile:
           type: RuntimeDefault
-      {{ if (and .ESSecretName .ESSecretKey) }}
+      {{- if or (and .ESSecretName .ESSecretKey) .KeystoreSecretName }}
       env:
+        {{- if (and .ESSecretName .ESSecretKey) }}
         - name: ES_PW
           valueFrom:
             secretKeyRef:
               name: {{ .ESSecretName }}
               key: {{ .ESSecretKey }}
-      {{ end }}
+        {{- end }}
+        {{- if .KeystoreSecretName }}
+        - name: KEYSTORE_PW
+          valueFrom:
+            secretKeyRef:
+              name: {{ .KeystoreSecretName }}
+              key: {{ .KeystorePasswordKey }}
+        {{- end }}
+      {{- end }}
       volumeMounts:
         - name: output
           mountPath: {{ .OutputDir }}
+        {{- if .KeystoreSecretName }}
+        - name: client-cert
+          mountPath: {{ .KeystoreMountPath }}
+          readOnly: true
+        {{- end }}
       command: [sh, -c]
       args:
         - |
@@ -45,6 +59,7 @@ spec:
           /support-diagnostics/diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify \
             {{if (and .ESSecretName .ESSecretKey) }} -u {{ .ESSecretKey }} --passwordText $ES_PW{{end}} \
             {{if .TLS}} -s --noVerify {{end}} \
+            {{if .KeystoreSecretName }} --pkiKeystore {{ .KeystoreMountPath }}/{{ .KeystoreFile }} --pkiPassText $KEYSTORE_PW{{end}} \
             -o .
           touch ready
           while true; do sleep 1; done;
@@ -63,4 +78,12 @@ spec:
   volumes:
     - name: output
       emptyDir: {}
+    {{- if .KeystoreSecretName }}
+    - name: client-cert
+      secret:
+        secretName: {{ .KeystoreSecretName }}
+        items:
+          - key: {{ .KeystoreFile }}
+            path: {{ .KeystoreFile }}
+    {{- end }}
   restartPolicy: Never

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -85,9 +85,12 @@ func supportedStackDiagTypesFor(eckVersion *version.Version) []string {
 type diagJob struct {
 	sync.RWMutex
 	extraction.RemoteSource
-	d     bool
-	timer *time.Timer
-	done  chan struct{}
+	// keystoreSecret is the name of a per-job Secret holding a PKCS12 client keystore. Empty when
+	// the target cluster does not require client certificate authentication.
+	keystoreSecret string
+	d              bool
+	timer          *time.Timer
+	done           chan struct{}
 }
 
 func (d *diagJob) StartTimer(dur time.Duration) <-chan time.Time {
@@ -155,7 +158,9 @@ func newDiagJobState(ctx context.Context, k *Kubectl, ns string, verbose bool, i
 }
 
 // scheduleJob creates a Pod to extract diagnostic data from an Elasticsearch cluster or Kibana called resourceName.
-func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName string, tls bool) error {
+// keystoreSecretName, if non-empty, identifies a Secret containing a PKCS12 client keystore that the diagnostic
+// Pod will mount and present during the TLS handshake (used when the target cluster requires client cert auth).
+func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName, keystoreSecretName string, tls bool) error {
 	podName := fmt.Sprintf("%s-%s-diag", resourceName, typ)
 	tpl, err := template.New("job").Parse(jobTemplate)
 	if err != nil {
@@ -166,17 +171,21 @@ func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName
 
 	buffer := new(bytes.Buffer)
 	data := map[string]interface{}{
-		"PodName":           podName,
-		"DiagnosticImage":   ds.diagnosticImage,
-		"Namespace":         ds.ns,
-		"ESSecretName":      esSecretName,
-		"ESSecretKey":       esSecretKey,
-		"SVCName":           fmt.Sprintf("%s-%s", resourceName, svcSuffix),
-		"Type":              diagnosticType,
-		"TLS":               tls,
-		"OutputDir":         podOutputDir,
-		"MainContainerName": podMainContainerName,
-		"ImagePullSecrets":  ds.imagePullSecrets,
+		"PodName":             podName,
+		"DiagnosticImage":     ds.diagnosticImage,
+		"Namespace":           ds.ns,
+		"ESSecretName":        esSecretName,
+		"ESSecretKey":         esSecretKey,
+		"SVCName":             fmt.Sprintf("%s-%s", resourceName, svcSuffix),
+		"Type":                diagnosticType,
+		"TLS":                 tls,
+		"OutputDir":           podOutputDir,
+		"MainContainerName":   podMainContainerName,
+		"ImagePullSecrets":    ds.imagePullSecrets,
+		"KeystoreSecretName":  keystoreSecretName,
+		"KeystoreFile":        keystoreFile,
+		"KeystorePasswordKey": keystorePasswordKey,
+		"KeystoreMountPath":   keystoreMountPath,
 	}
 	err = tpl.Execute(buffer, data)
 	if err != nil {
@@ -207,7 +216,8 @@ func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName
 			ResourceName: resourceName,
 			PodOutputDir: podOutputDir,
 		},
-		done: make(chan struct{}, 1),
+		keystoreSecret: keystoreSecretName,
+		done:           make(chan struct{}, 1),
 	}
 	// start a dedicated timer for each job and terminate the job when the timer expires.
 	go func(j *diagJob) {
@@ -375,10 +385,17 @@ func (ds *diagJobState) completeJob(job *diagJob) error {
 	return ds.terminateJob(ds.context, job)
 }
 
-// terminateJob marks job as done and deletes diagnostic Pod.
+// terminateJob marks job as done and deletes the diagnostic Pod plus any per-job keystore Secret.
 func (ds *diagJobState) terminateJob(ctx context.Context, job *diagJob) error {
 	job.MarkDone()
-	return ds.kubectl.CoreV1().Pods(ds.ns).Delete(ctx, job.PodName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)})
+	var errs []error
+	if err := ds.kubectl.CoreV1().Pods(ds.ns).Delete(ctx, job.PodName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, err)
+	}
+	if err := deleteKeystoreSecret(ctx, ds.kubectl, ds.ns, job.keystoreSecret); err != nil && !apierrors.IsNotFound(err) {
+		errs = append(errs, err)
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 // detectImageErrors tries to detect Image pull errors on the diagnostic container. Callers should then terminate the job
@@ -450,9 +467,38 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 			return nil
 		}
 
-		recordErr(state.scheduleJob(typ, esSecretName, esSecretKey, resourceName, isTLS))
+		// For Elasticsearch jobs, detect whether the target cluster requires client certificate
+		// authentication and, if so, materialise a per-job PKCS12 keystore Secret that the
+		// diagnostic Pod will mount. This is what allows the bundled support-diagnostics tool
+		// to complete the TLS handshake against an mTLS-enabled cluster.
+		var keystoreSecretName string
+		if typ == elasticsearchJob {
+			podName := fmt.Sprintf("%s-%s-diag", resourceName, typ)
+			name, err := setupClientKeystore(k, ns, esName, podName)
+			if err != nil {
+				recordErr(fmt.Errorf("while preparing client certificate for %s: %w", esName, err))
+				return nil
+			}
+			keystoreSecretName = name
+		}
+
+		recordErr(state.scheduleJob(typ, esSecretName, esSecretKey, resourceName, keystoreSecretName, isTLS))
 		return nil
 	})
+}
+
+// setupClientKeystore materialises a per-job PKCS12 keystore Secret for the given Elasticsearch
+// resource if the operator client certificate secret exists. Returns the empty string when the
+// cluster does not require client certificate authentication.
+func setupClientKeystore(k *Kubectl, ns, esName, podName string) (string, error) {
+	certPEM, keyPEM, found, err := loadOperatorClientCert(k, ns, esName)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", nil
+	}
+	return createKeystoreSecret(context.Background(), k, ns, podName, certPEM, keyPEM)
 }
 
 func extractEsInfo(typ string, ns string, resourceInfo *resource.Info) (bool, string, error) {

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -392,7 +392,7 @@ func (ds *diagJobState) terminateJob(ctx context.Context, job *diagJob) error {
 	if err := ds.kubectl.CoreV1().Pods(ds.ns).Delete(ctx, job.PodName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}); err != nil && !apierrors.IsNotFound(err) {
 		errs = append(errs, err)
 	}
-	if err := deleteKeystoreSecret(ctx, ds.kubectl, ds.ns, job.keystoreSecret); err != nil && !apierrors.IsNotFound(err) {
+	if err := deleteKeystoreSecret(ctx, ds.kubectl, ds.ns, job.keystoreSecret); err != nil {
 		errs = append(errs, err)
 	}
 	return utilerrors.NewAggregate(errs)

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -482,7 +482,12 @@ func scheduleJobs(k *Kubectl, ns string, recordErr func(error), state *diagJobSt
 			keystoreSecretName = name
 		}
 
-		recordErr(state.scheduleJob(typ, esSecretName, esSecretKey, resourceName, keystoreSecretName, isTLS))
+		if err := state.scheduleJob(typ, esSecretName, esSecretKey, resourceName, keystoreSecretName, isTLS); err != nil {
+			// scheduleJob failed before the job was registered, so terminateJob will never run for
+			// this resource. Clean up the keystore Secret here to avoid leaving key material behind.
+			recordErr(deleteKeystoreSecret(context.Background(), state.kubectl, ns, keystoreSecretName))
+			recordErr(err)
+		}
 		return nil
 	})
 }


### PR DESCRIPTION

## Summary

When eck-diagnostics is run against an Elasticsearch cluster that requires client certificate authentication (the operator sets the `eck.k8s.elastic.co/client-authentication-required` annotation and reconciles a `<esName>-es-internal-client-cert` Secret), the bundled `support-diagnostics` tool fails the very first request with:

```
javax.net.ssl.SSLHandshakeException: (certificate_required) Received fatal alert: certificate_required
    at co.elastic.support.rest.RestClient.execRequest(RestClient.java:86)
    at co.elastic.support.diagnostics.commands.CheckElasticsearchVersion.getElasticsearchVersion(...)
```

The TLS handshake is rejected by Elasticsearch because the diagnostic Pod presents no client certificate. The resulting archive contains only an error log under `default/elasticsearch/<esName>/diagnostics.log` and zero JSON payloads.

This change makes eck-diagnostics detect the operator-managed client certificate and feed it to `support-diagnostics` so the handshake succeeds and the full set of diagnostic data is collected.

## Approach

The bundled `support-diagnostics` 9.3.1 supports client certificate authentication via `--pkiKeystore <path> --pkiPassText <pwd>` (`ElasticRestClientInputs.java:66-72`), but `RestClient.java:204-206` loads the file with `KeyStore.load(FileInputStream, password)` - i.e. it requires a binary JKS/PKCS12 keystore, not the PEM material stored in the operator secret.

For each Elasticsearch resource being diagnosed, eck-diagnostics now:

1. Looks up `<esName>-es-internal-client-cert` in the resource's namespace (mirrors the lookup performed by cloud-on-k8s `certificates.LoadOperatorClientCertIfExists`). If absent, behavior is unchanged.
2. Builds an in-memory PKCS12 keystore from `tls.crt`/`tls.key` with a fresh per-run random password (`software.sslmate.com/src/go-pkcs12`).
3. Materializes a per-job Secret named `<podName>-keystore` holding `keystore.p12` and `password`, labelled `app.kubernetes.io/name=eck-diagnostics`.
4. Mounts that Secret into the diagnostic Pod and invokes `diagnostics.sh ... --pkiKeystore /client-cert/keystore.p12 --pkiPassText $KEYSTORE_PW` alongside the existing basic-auth flags.
5. Deletes the per-job Secret in `terminateJob` together with the diagnostic Pod (success, timeout, and abort paths).

The flow is gated on the secret's existence, so non-mTLS clusters are unaffected. Only the `elasticsearch` job type uses the cert (Kibana and Logstash diagnostics connect to their own services, not to ES, and the operator client cert is ES-namer-scoped).