### PR TITLE
Auto-detect stack service port for diagnostics

### DIFF
--- a/internal/job.tpl.yml
+++ b/internal/job.tpl.yml
@@ -45,6 +45,7 @@ spec:
           /support-diagnostics/diagnostics.sh -h {{.SVCName}} --type {{.Type}} --bypassDiagVerify \
             {{if (and .ESSecretName .ESSecretKey) }} -u {{ .ESSecretKey }} --passwordText $ES_PW{{end}} \
             {{if .TLS}} -s --noVerify {{end}} \
+            {{if .Port}} --port {{.Port}}{{end}} \
             -o .
           touch ready
           while true; do sleep 1; done;

--- a/internal/stackdiag.go
+++ b/internal/stackdiag.go
@@ -163,6 +163,8 @@ func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName
 	}
 
 	diagnosticType, svcSuffix := diagnosticTypeForApplication(typ)
+	svcName := fmt.Sprintf("%s-%s", resourceName, svcSuffix)
+	svcPort := ds.detectServicePort(svcName)
 
 	buffer := new(bytes.Buffer)
 	data := map[string]interface{}{
@@ -171,9 +173,10 @@ func (ds *diagJobState) scheduleJob(typ, esSecretName, esSecretKey, resourceName
 		"Namespace":         ds.ns,
 		"ESSecretName":      esSecretName,
 		"ESSecretKey":       esSecretKey,
-		"SVCName":           fmt.Sprintf("%s-%s", resourceName, svcSuffix),
+		"SVCName":           svcName,
 		"Type":              diagnosticType,
 		"TLS":               tls,
+		"Port":              svcPort,
 		"OutputDir":         podOutputDir,
 		"MainContainerName": podMainContainerName,
 		"ImagePullSecrets":  ds.imagePullSecrets,
@@ -239,6 +242,30 @@ func diagnosticTypeForApplication(typ string) (string, string) {
 		return "logstash-api", "ls-api"
 	}
 	panic("programming error: unknown type")
+}
+
+// detectServicePort looks up the Kubernetes service and returns the port it exposes, preferring a port named "http"
+// or "https", falling back to the first port. Returns 0 if the service cannot be found or has no ports, in which case
+// the diagnostic tool will use its own default.
+func (ds *diagJobState) detectServicePort(svcName string) int32 {
+	svcNsn := types.NamespacedName{Namespace: ds.ns, Name: svcName}
+	svc, err := ds.kubectl.CoreV1().Services(ds.ns).Get(context.Background(), svcName, metav1.GetOptions{})
+	if err != nil {
+		logger.Printf("Warning: could not detect port for service %q, using diagnostic tool default: %v", svcNsn, err)
+		return 0
+	}
+	for _, p := range svc.Spec.Ports {
+		if p.Name == "http" || p.Name == "https" {
+			return p.Port
+		}
+	}
+	if len(svc.Spec.Ports) > 0 {
+		port := svc.Spec.Ports[0].Port
+		logger.Printf("Warning: could not find https or http ports in service %q, using %d port from first entry", svcNsn, port)
+		return port
+	}
+	logger.Printf("Warning: service %q has no port definitions, using diagnostic tool default", svcNsn)
+	return 0
 }
 
 // extractFromRemote runs the equivalent of "kubectl cp" to extract the stack diagnostics from a remote Pod.

--- a/internal/stackdiag_test.go
+++ b/internal/stackdiag_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	_ "embed"
 	"reflect"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -15,6 +16,67 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 )
+
+func Test_jobTemplate_port(t *testing.T) {
+	tests := []struct {
+		name        string
+		port        int32
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "port flag injected when port is non-zero",
+			port:        443,
+			wantContain: "--port 443",
+		},
+		{
+			name:       "port flag absent when port is zero",
+			port:       0,
+			wantAbsent: "--port ",
+		},
+	}
+
+	baseData := map[string]interface{}{
+		"PodName":           "test-pod",
+		"DiagnosticImage":   "docker.elastic.co/eck-dev/support-diagnostics:latest",
+		"Namespace":         "default",
+		"ESSecretName":      "",
+		"ESSecretKey":       "",
+		"SVCName":           "my-kibana-kb-http",
+		"Type":              "kibana-api",
+		"TLS":               false,
+		"OutputDir":         "/diagnostic-output",
+		"MainContainerName": "stack-diagnostics",
+		"ImagePullSecrets":  nil,
+	}
+
+	tpl, err := template.New("job").Parse(jobTemplate)
+	if err != nil {
+		t.Fatalf("parsing template: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make(map[string]interface{}, len(baseData)+1)
+			for k, v := range baseData {
+				data[k] = v
+			}
+			data["Port"] = tt.port
+
+			buf := new(bytes.Buffer)
+			if err := tpl.Execute(buf, data); err != nil {
+				t.Fatalf("executing template: %v", err)
+			}
+			rendered := buf.String()
+			if tt.wantContain != "" && !strings.Contains(rendered, tt.wantContain) {
+				t.Errorf("expected rendered template to contain %q\nrendered:\n%s", tt.wantContain, rendered)
+			}
+			if tt.wantAbsent != "" && strings.Contains(rendered, tt.wantAbsent) {
+				t.Errorf("expected rendered template NOT to contain %q\nrendered:\n%s", tt.wantAbsent, rendered)
+			}
+		})
+	}
+}
 
 func Test_jobTemplate_imagePullSecrets(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Before scheduling each diagnostic pod, looks up the Kubernetes service it will connect to and reads the exposed port via a `Services.Get` call.
- The detected port is passed explicitly as `--port` to `diagnostics.sh`, overriding the per-type hardcoded defaults inside the `support-diagnostics` tool (9200 for Elasticsearch, 5601 for Kibana, 9600 for Logstash).
- Port selection prefers a port named `http` or `https`; falls back to the first entry in `spec.ports`; logs a warning and omits `--port` entirely if the service cannot be read, preserving the previous behaviour.
- Covers all three supported stack types: Elasticsearch (`<name>-es-http`), Kibana (`<name>-kb-http`), and Logstash (`<name>-ls-api`).
- No new CLI flags. No changes to existing behaviour when services expose their default ports.

Fixes https://github.com/elastic/eck-diagnostics/issues/398

## Why

ECK lets users expose Elasticsearch, Kibana, and Logstash on arbitrary ports via `spec.http.service.spec.ports` (ES/Kibana) and `spec.services` (Logstash). When a non-default port is configured, the `support-diagnostics` tool inside the diagnostic pod connects to the wrong port and times out:

```
org.apache.http.conn.ConnectTimeoutException: Connect to kibana-kb-http:5601 [kibana-kb-http/x.x.x.x] failed: Connect timed out
```

Static per-type CLI flags (`--kibana-port`, `--elasticsearch-port`, …) cannot solve this because a single invocation of `eck-diagnostics` may collect diagnostics from multiple instances of the same type running on different ports. Auto-detecting the port from the Kubernetes service solves it per-instance with no user input required.
