### PR TITLE
add operators.json with per-operator version, install method, and managed-namespace detection

### DIFF
--- a/internal/diag.go
+++ b/internal/diag.go
@@ -101,6 +101,9 @@ func Run(params Params) error {
 		"nodes.json": func(writer io.Writer) error {
 			return kubectl.GetByLabel("nodes", "", filters.Empty, writer)
 		},
+		"namespaces.json": func(writer io.Writer) error {
+			return kubectl.GetByLabel("namespaces", "", filters.Empty, writer)
+		},
 		"podsecuritypolicies.json": func(writer io.Writer) error {
 			return kubectl.GetByLabel("podsecuritypolicies", "", filters.Empty, writer)
 		},
@@ -117,6 +120,7 @@ func Run(params Params) error {
 
 	var operatorLabels []labels.Set
 	operatorVersions := make([]*version.Version, 0, len(params.OperatorNamespaces))
+	operatorInfos := make([]OperatorInfo, 0, len(params.OperatorNamespaces))
 	for _, ns := range params.OperatorNamespaces {
 		// Find the label in use by operator in this namespace and add this to
 		// the set of filters to ensure we always retrieve the objects
@@ -128,11 +132,21 @@ func Run(params Params) error {
 			operatorLabels = append(operatorLabels, operatorLabel)
 		}
 
-		operatorVersions = append(operatorVersions, detectECKVersion(clientSet, ns, params.ECKVersion))
+		info := detectOperatorInfo(clientSet, ns, params.ECKVersion)
+		operatorInfos = append(operatorInfos, info)
+		operatorVersions = append(operatorVersions, info.parsedVersion)
 	}
 
 	maxOperatorVersion := maxVersion(operatorVersions)
 	logVersion(maxOperatorVersion)
+
+	warnMissingNamespaces(clientSet, operatorInfos, params.AllNamespaces())
+
+	zipFile.Add(map[string]func(io.Writer) error{
+		"operators.json": func(w io.Writer) error {
+			return writeOperatorsJSON(w, operatorInfos)
+		},
+	})
 
 	allNamespaces := sets.New(params.ResourcesNamespaces...)
 	allNamespaces.Insert(params.OperatorNamespaces...)

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -144,8 +144,12 @@ func detectManagedNamespaces(c kubernetes.Interface, namespace string, podTempla
 			continue
 		}
 
-		if val := extractFlagValue(container.Args, "--namespaces"); val != "" {
-			return ManagedNamespaces{All: false, Static: splitCSV(val)}
+		if vals := extractAllFlagValues(container.Args, "--namespaces"); len(vals) > 0 {
+			var namespaces []string
+			for _, v := range vals {
+				namespaces = append(namespaces, splitCSV(v)...)
+			}
+			return ManagedNamespaces{All: false, Static: namespaces}
 		}
 
 		for _, env := range container.Env {
@@ -191,7 +195,7 @@ func detectManagedNamespaces(c kubernetes.Interface, namespace string, podTempla
 	return ManagedNamespaces{All: true}
 }
 
-// extractFlagValue finds the value of --flag value or --flag=value in a list of args.
+// extractFlagValue finds the value of --flag value or --flag=value in a list of args, returning the first match.
 func extractFlagValue(args []string, flag string) string {
 	for i, arg := range args {
 		if v, ok := strings.CutPrefix(arg, flag+"="); ok {
@@ -202,6 +206,22 @@ func extractFlagValue(args []string, flag string) string {
 		}
 	}
 	return ""
+}
+
+// extractAllFlagValues collects every occurrence of --flag value or --flag=value in args.
+// Use this for flags that may appear multiple times (e.g. --namespaces=a --namespaces=b).
+func extractAllFlagValues(args []string, flag string) []string {
+	var vals []string
+	for i, arg := range args {
+		if v, ok := strings.CutPrefix(arg, flag+"="); ok {
+			vals = append(vals, v)
+			continue
+		}
+		if arg == flag && i+1 < len(args) {
+			vals = append(vals, args[i+1])
+		}
+	}
+	return vals
 }
 
 // findConfigMapForPath traces a mounted config file path back to the ConfigMap name and data key

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubectl/pkg/util/fieldpath"
 )
 
 // ManagedNamespaces describes which namespaces an ECK operator instance manages.
@@ -257,25 +258,11 @@ func resolveEnvValueFromFieldRef(podMeta metav1.ObjectMeta, src *corev1.EnvVarSo
 	if src == nil || src.FieldRef == nil {
 		return ""
 	}
-	annotationKey := annotationKeyFromFieldPath(src.FieldRef.FieldPath)
-	if annotationKey == "" {
+	base, key, ok := fieldpath.SplitMaybeSubscriptedPath(src.FieldRef.FieldPath)
+	if !ok || base != "metadata.annotations" {
 		return ""
 	}
-	return podMeta.Annotations[annotationKey]
-}
-
-// annotationKeyFromFieldPath extracts the annotation key from a fieldPath of the form
-// metadata.annotations['<key>'], returning "" for any other form.
-func annotationKeyFromFieldPath(fieldPath string) string {
-	trimmed, ok := strings.CutPrefix(fieldPath, "metadata.annotations['")
-	if !ok {
-		return ""
-	}
-	key, ok := strings.CutSuffix(trimmed, "']")
-	if !ok {
-		return ""
-	}
-	return key
+	return podMeta.Annotations[key]
 }
 
 // parseManagedNamespacesFromConfigMap parses the operator config from the given ConfigMap data key.

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -39,7 +39,7 @@ type OperatorInfo struct {
 }
 
 // detectOperatorInfo gathers metadata about the ECK operator running in the given namespace.
-func detectOperatorInfo(c *kubernetes.Clientset, namespace, userSpecifiedVersion string) OperatorInfo {
+func detectOperatorInfo(c kubernetes.Interface, namespace, userSpecifiedVersion string) OperatorInfo {
 	info := OperatorInfo{
 		Namespace:         namespace,
 		Version:           "unknown",
@@ -100,7 +100,7 @@ func podTemplateFromStatefulSet(sset *appsv1.StatefulSet, info *OperatorInfo, us
 	return sset.Spec.Template
 }
 
-func podTemplateFromDeployment(c *kubernetes.Clientset, namespace string, info *OperatorInfo, userSpecifiedVersion string) (corev1.PodTemplateSpec, error) {
+func podTemplateFromDeployment(c kubernetes.Interface, namespace string, info *OperatorInfo, userSpecifiedVersion string) (corev1.PodTemplateSpec, error) {
 	deployment, err := c.AppsV1().Deployments(namespace).Get(context.Background(), "elastic-operator", metav1.GetOptions{})
 	if err != nil {
 		return corev1.PodTemplateSpec{}, fmt.Errorf("operator statefulset not found, checking for OLM deployment but failed: %w", err)
@@ -338,7 +338,7 @@ func splitCSV(s string) []string {
 }
 
 // warnMissingNamespaces logs a warning for each managed namespace not covered by collectedNamespaces.
-func warnMissingNamespaces(c *kubernetes.Clientset, infos []OperatorInfo, collectedNamespaces []string) {
+func warnMissingNamespaces(c kubernetes.Interface, infos []OperatorInfo, collectedNamespaces []string) {
 	collectedNamespacesSet := sets.New(collectedNamespaces...)
 
 	for _, info := range infos {
@@ -366,7 +366,7 @@ func warnMissingNamespaces(c *kubernetes.Clientset, infos []OperatorInfo, collec
 }
 
 // namespacesMatchingSelector lists cluster namespaces whose labels match the given selector.
-func namespacesMatchingSelector(c *kubernetes.Clientset, selector *metav1.LabelSelector) ([]string, error) {
+func namespacesMatchingSelector(c kubernetes.Interface, selector *metav1.LabelSelector) ([]string, error) {
 	sel, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
 		return nil, err

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -52,6 +52,8 @@ func detectOperatorInfo(c *kubernetes.Clientset, namespace, userSpecifiedVersion
 		if v, err := version.ParseSemantic(userSpecifiedVersion); err == nil {
 			info.parsedVersion = v
 			info.Version = v.String()
+		} else {
+			logger.Printf("WARNING: could not parse --eck-version %q: %v", userSpecifiedVersion, err)
 		}
 	}
 

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -213,7 +213,7 @@ func findConfigMapForPath(podSpec corev1.PodSpec, container corev1.Container, co
 			relPath = vm.SubPath
 			break
 		}
-		if vm.SubPath == "" && strings.HasPrefix(configPath, vm.MountPath) {
+		if vm.SubPath == "" && (configPath == vm.MountPath || strings.HasPrefix(configPath, strings.TrimSuffix(vm.MountPath, "/")+"/")) {
 			mountName = vm.Name
 			mountPath = vm.MountPath
 			break

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -342,7 +343,9 @@ func warnMissingNamespaces(c *kubernetes.Clientset, infos []OperatorInfo, collec
 		mn := info.ManagedNamespaces
 		switch {
 		case mn.All:
-			logger.Printf("WARNING: Operator in namespace %q manages all namespaces; the diagnostic only collects resources from %v. Specify additional workload namespaces via --resources-namespaces to broaden coverage.", info.Namespace, collectedNamespacesSet.UnsortedList())
+			collected := collectedNamespacesSet.UnsortedList()
+			sort.Strings(collected)
+			logger.Printf("INFO: Operator in namespace %q manages all namespaces; this diagnostic collects resources from %v. Use --resources-namespaces to include additional namespaces if needed.", info.Namespace, collected)
 		case mn.Selector != nil:
 			managed, err := namespacesMatchingSelector(c, mn.Selector)
 			if err != nil {

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -1,0 +1,396 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ManagedNamespaces describes which namespaces an ECK operator instance manages.
+// Exactly one of Static or Selector is set when All is false.
+type ManagedNamespaces struct {
+	All      bool                  `json:"all"`
+	Static   []string              `json:"static,omitempty"`
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+}
+
+// OperatorInfo contains metadata about a single ECK operator instance.
+type OperatorInfo struct {
+	Namespace         string            `json:"namespace"`
+	Version           string            `json:"version"`
+	ManagedNamespaces ManagedNamespaces `json:"managed_namespaces"`
+	InstallMethod     string            `json:"install_method"`
+	parsedVersion     *version.Version
+}
+
+// detectOperatorInfo gathers metadata about the ECK operator running in the given namespace.
+func detectOperatorInfo(c *kubernetes.Clientset, namespace, userSpecifiedVersion string) OperatorInfo {
+	info := OperatorInfo{
+		Namespace:         namespace,
+		Version:           "unknown",
+		InstallMethod:     "unknown",
+		ManagedNamespaces: ManagedNamespaces{All: true},
+		parsedVersion:     fallbackMaxVersion,
+	}
+
+	if userSpecifiedVersion != "" {
+		if v, err := version.ParseSemantic(userSpecifiedVersion); err == nil {
+			info.parsedVersion = v
+			info.Version = v.String()
+		}
+	}
+
+	sset, err := findOperatorStatefulSet(c, namespace)
+	if err != nil {
+		logger.Printf("Error finding operator StatefulSet in namespace %s: %v", namespace, err)
+		return info
+	}
+
+	var podTemplate corev1.PodTemplateSpec
+	if sset != nil {
+		podTemplate = podTemplateFromStatefulSet(sset, &info, userSpecifiedVersion)
+	} else {
+		pt, err := podTemplateFromDeployment(c, namespace, &info, userSpecifiedVersion)
+		if err != nil {
+			logger.Println(err.Error())
+			return info
+		}
+		podTemplate = pt
+	}
+
+	info.ManagedNamespaces = detectManagedNamespaces(c, namespace, podTemplate)
+	return info
+}
+
+// versionFromStatefulSet extracts the ECK version from a StatefulSet, preferring the standard
+// app.kubernetes.io/version label (available since ECK 1.3) and falling back to the container image tag.
+func versionFromStatefulSet(sset *appsv1.StatefulSet) *version.Version {
+	if v, err := version.ParseSemantic(sset.Labels["app.kubernetes.io/version"]); err == nil {
+		return v
+	}
+	return extractVersionFromContainers(sset.Spec.Template.Spec.Containers)
+}
+
+func podTemplateFromStatefulSet(sset *appsv1.StatefulSet, info *OperatorInfo, userSpecifiedVersion string) corev1.PodTemplateSpec {
+	info.InstallMethod = detectInstallMethod(sset.Labels)
+	if userSpecifiedVersion == "" {
+		v := versionFromStatefulSet(sset)
+		info.parsedVersion = v
+		if v != fallbackMaxVersion {
+			info.Version = v.String()
+		}
+	}
+	return sset.Spec.Template
+}
+
+func podTemplateFromDeployment(c *kubernetes.Clientset, namespace string, info *OperatorInfo, userSpecifiedVersion string) (corev1.PodTemplateSpec, error) {
+	deployment, err := c.AppsV1().Deployments(namespace).Get(context.Background(), "elastic-operator", metav1.GetOptions{})
+	if err != nil {
+		return corev1.PodTemplateSpec{}, fmt.Errorf("operator statefulset not found, checking for OLM deployment but failed: %w", err)
+	}
+	info.InstallMethod = detectInstallMethod(deployment.Labels)
+	if userSpecifiedVersion == "" {
+		v, verr := extractVersionFromOLMMetadata(deployment.Labels)
+		if verr != nil {
+			logger.Println("ECK operator not found in OLM metadata checking container image as last resort")
+			v = extractVersionFromContainers(deployment.Spec.Template.Spec.Containers)
+		}
+		info.parsedVersion = v
+		if v != fallbackMaxVersion {
+			info.Version = v.String()
+		}
+	}
+	return deployment.Spec.Template, nil
+}
+
+// detectInstallMethod infers the installation method from operator labels.
+// Works for both StatefulSet (helm/yaml) and Deployment (olm) label sets.
+func detectInstallMethod(lbls map[string]string) string {
+	if chart, ok := lbls["helm.sh/chart"]; ok && strings.Contains(chart, "eck-operator") {
+		return "helm"
+	}
+	if _, ok := lbls["control-plane"]; ok {
+		return "yaml"
+	}
+	if _, ok := lbls["olm.owner"]; ok {
+		return "olm"
+	}
+	return "unknown"
+}
+
+// detectManagedNamespaces reads the operator's managed namespaces from args, env vars, or config file,
+// following Viper's precedence: CLI arg > env var > config file.
+func detectManagedNamespaces(c kubernetes.Interface, namespace string, podTemplate corev1.PodTemplateSpec) ManagedNamespaces {
+	for _, container := range podTemplate.Spec.Containers {
+		if container.Name != "manager" {
+			continue
+		}
+
+		if val := extractFlagValue(container.Args, "--namespaces"); val != "" {
+			return ManagedNamespaces{All: false, Static: splitCSV(val)}
+		}
+
+		for _, env := range container.Env {
+			if env.Name != "NAMESPACES" {
+				continue
+			}
+			if env.Value != "" {
+				return ManagedNamespaces{All: false, Static: splitCSV(env.Value)}
+			}
+			if val := resolveEnvValueFromFieldRef(podTemplate.ObjectMeta, env.ValueFrom); val != "" {
+				return ManagedNamespaces{All: false, Static: splitCSV(val)}
+			}
+		}
+
+		configPath := extractFlagValue(container.Args, "--config")
+		if configPath == "" {
+			break
+		}
+		cmName, dataKey := findConfigMapForPath(podTemplate.Spec, container, configPath)
+		if cmName == "" || dataKey == "" {
+			logger.Printf("WARNING: operator in namespace %q uses --config=%s but the config source could not "+
+				"be traced to a ConfigMap (may be mounted from a Secret); managed namespaces reported as all",
+				namespace, configPath)
+			break
+		}
+		cm, err := c.CoreV1().ConfigMaps(namespace).Get(context.Background(), cmName, metav1.GetOptions{})
+		if err != nil {
+			logger.Printf("WARNING: operator in namespace %q: could not read ConfigMap %q: %v; managed "+
+				"namespaces reported as all", namespace, cmName, err)
+			break
+		}
+		ns, err := parseManagedNamespacesFromConfigMap(cm.Data, dataKey)
+		if err != nil {
+			logger.Printf("WARNING: operator in namespace %q: could not parse ConfigMap %q key %q: %v; managed "+
+				"namespaces reported as all", namespace, cmName, dataKey, err)
+			break
+		}
+		if ns != nil {
+			return *ns
+		}
+		break
+	}
+	return ManagedNamespaces{All: true}
+}
+
+// extractFlagValue finds the value of --flag value or --flag=value in a list of args.
+func extractFlagValue(args []string, flag string) string {
+	for i, arg := range args {
+		if v, ok := strings.CutPrefix(arg, flag+"="); ok {
+			return v
+		}
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// findConfigMapForPath traces a mounted config file path back to the ConfigMap name and data key
+// that provides it. When the volume uses an items mapping, the key is resolved via the item whose
+// path matches; otherwise the filename relative to the mount point is used as the key.
+func findConfigMapForPath(podSpec corev1.PodSpec, container corev1.Container, configPath string) (cmName, dataKey string) {
+	var mountName, mountPath, relPath string
+	for _, vm := range container.VolumeMounts {
+		// SubPath mounts a single file: mountPath IS the file path, so require an exact match.
+		if vm.SubPath != "" && configPath == vm.MountPath {
+			mountName = vm.Name
+			mountPath = vm.MountPath
+			relPath = vm.SubPath
+			break
+		}
+		if vm.SubPath == "" && strings.HasPrefix(configPath, vm.MountPath) {
+			mountName = vm.Name
+			mountPath = vm.MountPath
+			break
+		}
+	}
+	if mountName == "" {
+		return "", ""
+	}
+	if relPath == "" {
+		relPath = strings.TrimPrefix(configPath, strings.TrimSuffix(mountPath, "/")+"/")
+	}
+	for _, vol := range podSpec.Volumes {
+		if vol.Name != mountName || vol.ConfigMap == nil {
+			continue
+		}
+		if len(vol.ConfigMap.Items) == 0 {
+			return vol.ConfigMap.Name, relPath
+		}
+		for _, item := range vol.ConfigMap.Items {
+			if item.Path == relPath {
+				return vol.ConfigMap.Name, item.Key
+			}
+		}
+		return "", ""
+	}
+	return "", ""
+}
+
+type eckConfig struct {
+	Namespaces        any                   `json:"namespaces"`
+	NamespaceSelector *metav1.LabelSelector `json:"namespace-selector"`
+}
+
+// resolveEnvValueFromFieldRef resolves a ValueFrom annotation field ref against the pod template
+// metadata. OLM injects olm.targetNamespaces into the Deployment's pod template annotations, so
+// the value is available without querying running pods.
+func resolveEnvValueFromFieldRef(podMeta metav1.ObjectMeta, src *corev1.EnvVarSource) string {
+	if src == nil || src.FieldRef == nil {
+		return ""
+	}
+	annotationKey := annotationKeyFromFieldPath(src.FieldRef.FieldPath)
+	if annotationKey == "" {
+		return ""
+	}
+	return podMeta.Annotations[annotationKey]
+}
+
+// annotationKeyFromFieldPath extracts the annotation key from a fieldPath of the form
+// metadata.annotations['<key>'], returning "" for any other form.
+func annotationKeyFromFieldPath(fieldPath string) string {
+	trimmed, ok := strings.CutPrefix(fieldPath, "metadata.annotations['")
+	if !ok {
+		return ""
+	}
+	key, ok := strings.CutSuffix(trimmed, "']")
+	if !ok {
+		return ""
+	}
+	return key
+}
+
+// parseManagedNamespacesFromConfigMap parses the operator config from the given ConfigMap data key.
+// Returns (nil, nil) when the config is valid but contains no namespace restriction.
+func parseManagedNamespacesFromConfigMap(data map[string]string, key string) (*ManagedNamespaces, error) {
+	content, ok := data[key]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found in ConfigMap data", key)
+	}
+	var cfg eckConfig
+	if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	if cfg.NamespaceSelector != nil &&
+		(len(cfg.NamespaceSelector.MatchLabels) > 0 || len(cfg.NamespaceSelector.MatchExpressions) > 0) {
+		return &ManagedNamespaces{All: false, Selector: cfg.NamespaceSelector}, nil
+	}
+	nss, err := parseNamespacesValue(cfg.Namespaces)
+	if err != nil {
+		return nil, err
+	}
+	if len(nss) > 0 {
+		return &ManagedNamespaces{All: false, Static: nss}, nil
+	}
+	return nil, nil
+}
+
+// parseNamespacesValue handles both []any (YAML sequence) and string (comma-separated).
+func parseNamespacesValue(v any) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch val := v.(type) {
+	case []any:
+		result := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok && s != "" {
+				result = append(result, strings.TrimSpace(s))
+			}
+		}
+		return result, nil
+	case string:
+		return splitCSV(val), nil
+	default:
+		return nil, fmt.Errorf("namespaces field has unexpected type %T", v)
+	}
+}
+
+// splitCSV splits a comma-separated list, trimming whitespace from each entry.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// warnMissingNamespaces logs a warning for each managed namespace not covered by collectedNamespaces.
+func warnMissingNamespaces(c *kubernetes.Clientset, infos []OperatorInfo, collectedNamespaces []string) {
+	collectedNamespacesSet := sets.New(collectedNamespaces...)
+
+	for _, info := range infos {
+		mn := info.ManagedNamespaces
+		switch {
+		case mn.All:
+			logger.Printf("WARNING: Operator in namespace %q manages all namespaces; the diagnostic only collects resources from %v. Specify additional workload namespaces via --resources-namespaces to broaden coverage.", info.Namespace, collectedNamespacesSet.UnsortedList())
+		case mn.Selector != nil:
+			managed, err := namespacesMatchingSelector(c, mn.Selector)
+			if err != nil {
+				logger.Printf("WARNING: Could not evaluate namespace selector for operator in %q: %v", info.Namespace, err)
+				continue
+			}
+			if missing := missingNamespaces(managed, collectedNamespacesSet); len(missing) > 0 {
+				logger.Printf("WARNING: Operator in namespace %q manages namespaces %v (via selector) which are not included in this diagnostic. Use --resources-namespaces to include them.", info.Namespace, missing)
+			}
+		case len(mn.Static) > 0:
+			if missing := missingNamespaces(mn.Static, collectedNamespacesSet); len(missing) > 0 {
+				logger.Printf("WARNING: Operator in namespace %q manages namespaces %v which are not included in this diagnostic. Use --resources-namespaces to include them.", info.Namespace, missing)
+			}
+		}
+	}
+}
+
+// namespacesMatchingSelector lists cluster namespaces whose labels match the given selector.
+func namespacesMatchingSelector(c *kubernetes.Clientset, selector *metav1.LabelSelector) ([]string, error) {
+	sel, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+	nsList, err := c.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{
+		LabelSelector: sel.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, len(nsList.Items))
+	for i, ns := range nsList.Items {
+		result[i] = ns.Name
+	}
+	return result, nil
+}
+
+// missingNamespaces returns entries from managed that are absent from collected.
+func missingNamespaces(managed []string, collected sets.Set[string]) []string {
+	var missing []string
+	for _, ns := range managed {
+		if _, ok := collected[ns]; !ok {
+			missing = append(missing, ns)
+		}
+	}
+	return missing
+}
+
+// writeOperatorsJSON serialises a slice of OperatorInfo as a JSON array to w.
+func writeOperatorsJSON(w io.Writer, infos []OperatorInfo) error {
+	return json.NewEncoder(w).Encode(infos)
+}

--- a/internal/operator.go
+++ b/internal/operator.go
@@ -145,7 +145,7 @@ func detectManagedNamespaces(c kubernetes.Interface, namespace string, podTempla
 		}
 
 		if vals := extractAllFlagValues(container.Args, "--namespaces"); len(vals) > 0 {
-			var namespaces []string
+			namespaces := make([]string, 0, len(vals))
 			for _, v := range vals {
 				namespaces = append(namespaces, splitCSV(v)...)
 			}

--- a/internal/operator_test.go
+++ b/internal/operator_test.go
@@ -103,6 +103,48 @@ func Test_extractFlagValue(t *testing.T) {
 	}
 }
 
+func Test_extractAllFlagValues(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+		want []string
+	}{
+		{
+			name: "single occurrence",
+			args: []string{"--namespaces=ns1"},
+			flag: "--namespaces",
+			want: []string{"ns1"},
+		},
+		{
+			name: "repeated flag",
+			args: []string{"--namespaces=ns1", "--namespaces=ns2"},
+			flag: "--namespaces",
+			want: []string{"ns1", "ns2"},
+		},
+		{
+			name: "space-separated form repeated",
+			args: []string{"--namespaces", "ns1", "--namespaces", "ns2"},
+			flag: "--namespaces",
+			want: []string{"ns1", "ns2"},
+		},
+		{
+			name: "flag not present",
+			args: []string{"--other=value"},
+			flag: "--namespaces",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAllFlagValues(tt.args, tt.flag)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractAllFlagValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_splitCSV(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -466,6 +508,19 @@ func Test_detectManagedNamespaces(t *testing.T) {
 		podTemplate corev1.PodTemplateSpec
 		want        ManagedNamespaces
 	}{
+		{
+			name: "repeated --namespaces flags are merged",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Args:  []string{"--namespaces=ns1", "--namespaces=ns2,ns3"},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: false, Static: []string{"ns1", "ns2", "ns3"}},
+		},
 		{
 			name: "arg wins over env var",
 			podTemplate: corev1.PodTemplateSpec{

--- a/internal/operator_test.go
+++ b/internal/operator_test.go
@@ -8,8 +8,11 @@ import (
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_detectInstallMethod(t *testing.T) {
@@ -533,6 +536,216 @@ func Test_detectManagedNamespaces(t *testing.T) {
 			got := detectManagedNamespaces(nil, "elastic-system", tt.podTemplate)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("detectManagedNamespaces() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_detectOperatorInfo(t *testing.T) {
+	const ns = "elastic-system"
+
+	tests := []struct {
+		name                 string
+		objects              []appsv1.StatefulSet
+		deployments          []appsv1.Deployment
+		userSpecifiedVersion string
+		wantVersion          string
+		wantInstallMethod    string
+		wantManagedNS        ManagedNamespaces
+	}{
+		{
+			name: "StatefulSet path: version from label, yaml install, all namespaces",
+			objects: []appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels: map[string]string{
+						"control-plane":             "elastic-operator",
+						"app.kubernetes.io/version": "2.14.0",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager", Image: "docker.elastic.co/eck/eck-operator:2.14.0"}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.14.0",
+			wantInstallMethod: "yaml",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+		{
+			name: "StatefulSet path: user-specified version overrides label",
+			objects: []appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels: map[string]string{
+						"control-plane":             "elastic-operator",
+						"app.kubernetes.io/version": "2.14.0",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager"}},
+						},
+					},
+				},
+			}},
+			userSpecifiedVersion: "2.13.0",
+			wantVersion:          "2.13.0",
+			wantInstallMethod:    "yaml",
+			wantManagedNS:        ManagedNamespaces{All: true},
+		},
+		{
+			name: "StatefulSet path: helm install detected from labels",
+			objects: []appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels: map[string]string{
+						"helm.sh/chart":                "eck-operator-2.14.0",
+						"app.kubernetes.io/managed-by": "Helm",
+						"app.kubernetes.io/version":    "2.14.0",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager"}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.14.0",
+			wantInstallMethod: "helm",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+		{
+			name: "StatefulSet path: managed namespaces from --namespaces flag",
+			objects: []appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels: map[string]string{
+						"control-plane":             "elastic-operator",
+						"app.kubernetes.io/version": "2.14.0",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "manager",
+								Image: "docker.elastic.co/eck/eck-operator:2.14.0",
+								Args:  []string{"--namespaces=ns1,ns2"},
+							}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.14.0",
+			wantInstallMethod: "yaml",
+			wantManagedNS:     ManagedNamespaces{All: false, Static: []string{"ns1", "ns2"}},
+		},
+		{
+			name: "OLM Deployment path: version from OLM label",
+			deployments: []appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels: map[string]string{
+						"olm.owner": "elastic-operator.2.14.0",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "manager"}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.14.0",
+			wantInstallMethod: "olm",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+		{
+			name:              "no operator found returns defaults",
+			wantVersion:       "unknown",
+			wantInstallMethod: "unknown",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+		{
+			name: "StatefulSet path: version falls back to container image tag",
+			objects: []appsv1.StatefulSet{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels:    map[string]string{"control-plane": "elastic-operator"},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "manager",
+								Image: "docker.elastic.co/eck/eck-operator:2.13.0",
+							}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.13.0",
+			wantInstallMethod: "yaml",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+		{
+			name: "OLM Deployment path: version falls back to container image tag",
+			deployments: []appsv1.Deployment{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "elastic-operator",
+					Namespace: ns,
+					Labels:    map[string]string{"olm.owner": "elastic-operator"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  "manager",
+								Image: "docker.elastic.co/eck/eck-operator:2.13.0",
+							}},
+						},
+					},
+				},
+			}},
+			wantVersion:       "2.13.0",
+			wantInstallMethod: "olm",
+			wantManagedNS:     ManagedNamespaces{All: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []runtime.Object
+			for i := range tt.objects {
+				objs = append(objs, &tt.objects[i])
+			}
+			for i := range tt.deployments {
+				objs = append(objs, &tt.deployments[i])
+			}
+			c := fake.NewSimpleClientset(objs...)
+			got := detectOperatorInfo(c, ns, tt.userSpecifiedVersion)
+			if got.Version != tt.wantVersion {
+				t.Errorf("Version = %q, want %q", got.Version, tt.wantVersion)
+			}
+			if got.InstallMethod != tt.wantInstallMethod {
+				t.Errorf("InstallMethod = %q, want %q", got.InstallMethod, tt.wantInstallMethod)
+			}
+			if !reflect.DeepEqual(got.ManagedNamespaces, tt.wantManagedNS) {
+				t.Errorf("ManagedNamespaces = %+v, want %+v", got.ManagedNamespaces, tt.wantManagedNS)
 			}
 		})
 	}

--- a/internal/operator_test.go
+++ b/internal/operator_test.go
@@ -267,6 +267,14 @@ func Test_findConfigMapForPath(t *testing.T) {
 			wantDataKey: "",
 		},
 		{
+			name:        "mount at /conf does not match configPath /config/eck.yaml",
+			podSpec:     corev1.PodSpec{Volumes: baseVolumes},
+			container:   baseContainer,
+			configPath:  "/config/eck.yaml",
+			wantCMName:  "",
+			wantDataKey: "",
+		},
+		{
 			name: "subPath with items remapping resolves to mapped key",
 			podSpec: corev1.PodSpec{
 				Volumes: []corev1.Volume{{

--- a/internal/operator_test.go
+++ b/internal/operator_test.go
@@ -1,0 +1,531 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_detectInstallMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "helm install",
+			labels: map[string]string{"helm.sh/chart": "eck-operator-2.14.0", "app.kubernetes.io/managed-by": "Helm"},
+			want:   "helm",
+		},
+		{
+			name:   "yaml install",
+			labels: map[string]string{"control-plane": "elastic-operator"},
+			want:   "yaml",
+		},
+		{
+			name:   "olm install",
+			labels: map[string]string{"olm.owner": "elastic-operator.2.14.0", "olm.owner.kind": "ClusterServiceVersion"},
+			want:   "olm",
+		},
+		{
+			name:   "unknown",
+			labels: map[string]string{"some-other-label": "value"},
+			want:   "unknown",
+		},
+		{
+			name:   "empty labels",
+			labels: map[string]string{},
+			want:   "unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectInstallMethod(tt.labels); got != tt.want {
+				t.Errorf("detectInstallMethod() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractFlagValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		flag string
+		want string
+	}{
+		{
+			name: "--flag=value form",
+			args: []string{"--config=/conf/eck.yaml", "--other=x"},
+			flag: "--config",
+			want: "/conf/eck.yaml",
+		},
+		{
+			name: "--flag value form",
+			args: []string{"--config", "/conf/eck.yaml", "--other", "x"},
+			flag: "--config",
+			want: "/conf/eck.yaml",
+		},
+		{
+			name: "--namespaces with csv",
+			args: []string{"--namespaces=ns1,ns2,ns3"},
+			flag: "--namespaces",
+			want: "ns1,ns2,ns3",
+		},
+		{
+			name: "flag not present",
+			args: []string{"--other=value"},
+			flag: "--namespaces",
+			want: "",
+		},
+		{
+			name: "flag at end with no value",
+			args: []string{"--config"},
+			flag: "--config",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractFlagValue(tt.args, tt.flag); got != tt.want {
+				t.Errorf("extractFlagValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitCSV(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "single", input: "ns1", want: []string{"ns1"}},
+		{name: "multiple", input: "ns1,ns2,ns3", want: []string{"ns1", "ns2", "ns3"}},
+		{name: "with spaces", input: " ns1 , ns2 ", want: []string{"ns1", "ns2"}},
+		{name: "empty string", input: "", want: []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCSV(tt.input)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitCSV() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_findConfigMapForPath(t *testing.T) {
+	baseVolumes := []corev1.Volume{
+		{
+			Name: "config-vol",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+				},
+			},
+		},
+		{
+			Name: "secret-vol",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "some-secret"},
+			},
+		},
+	}
+	baseContainer := corev1.Container{
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "config-vol", MountPath: "/conf"},
+			{Name: "secret-vol", MountPath: "/certs"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		podSpec     corev1.PodSpec
+		container   corev1.Container
+		configPath  string
+		wantCMName  string
+		wantDataKey string
+	}{
+		{
+			name:        "standard mount, key from filename",
+			podSpec:     corev1.PodSpec{Volumes: baseVolumes},
+			container:   baseContainer,
+			configPath:  "/conf/eck.yaml",
+			wantCMName:  "elastic-operator",
+			wantDataKey: "eck.yaml",
+		},
+		{
+			name:        "custom config filename",
+			podSpec:     corev1.PodSpec{Volumes: baseVolumes},
+			container:   baseContainer,
+			configPath:  "/conf/operator.yaml",
+			wantCMName:  "elastic-operator",
+			wantDataKey: "operator.yaml",
+		},
+		{
+			name: "items mapping remaps key",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+							Items:                []corev1.KeyToPath{{Key: "my-config", Path: "eck.yaml"}},
+						},
+					},
+				}},
+			},
+			container:   baseContainer,
+			configPath:  "/conf/eck.yaml",
+			wantCMName:  "elastic-operator",
+			wantDataKey: "my-config",
+		},
+		{
+			name: "items mapping with no matching path returns empty",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+							Items:                []corev1.KeyToPath{{Key: "my-config", Path: "other.yaml"}},
+						},
+					},
+				}},
+			},
+			container:   baseContainer,
+			configPath:  "/conf/eck.yaml",
+			wantCMName:  "",
+			wantDataKey: "",
+		},
+		{
+			name:        "no matching mount",
+			podSpec:     corev1.PodSpec{Volumes: baseVolumes},
+			container:   baseContainer,
+			configPath:  "/other/file.yaml",
+			wantCMName:  "",
+			wantDataKey: "",
+		},
+		{
+			name:        "secret volume returns empty",
+			podSpec:     corev1.PodSpec{Volumes: baseVolumes},
+			container:   baseContainer,
+			configPath:  "/certs/tls.crt",
+			wantCMName:  "",
+			wantDataKey: "",
+		},
+		{
+			name: "subPath single-file mount uses subPath as key",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+						},
+					},
+				}},
+			},
+			container: corev1.Container{
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "config-vol", MountPath: "/conf/operator.yaml", SubPath: "operator.yaml"},
+				},
+			},
+			configPath:  "/conf/operator.yaml",
+			wantCMName:  "elastic-operator",
+			wantDataKey: "operator.yaml",
+		},
+		{
+			name: "subPath mount does not match different configPath",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+						},
+					},
+				}},
+			},
+			container: corev1.Container{
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "config-vol", MountPath: "/conf/operator.yaml", SubPath: "operator.yaml"},
+				},
+			},
+			configPath:  "/conf/eck.yaml",
+			wantCMName:  "",
+			wantDataKey: "",
+		},
+		{
+			name: "subPath with items remapping resolves to mapped key",
+			podSpec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{
+					Name: "config-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "elastic-operator"},
+							Items:                []corev1.KeyToPath{{Key: "my-config", Path: "operator.yaml"}},
+						},
+					},
+				}},
+			},
+			container: corev1.Container{
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "config-vol", MountPath: "/conf/operator.yaml", SubPath: "operator.yaml"},
+				},
+			},
+			configPath:  "/conf/operator.yaml",
+			wantCMName:  "elastic-operator",
+			wantDataKey: "my-config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCM, gotKey := findConfigMapForPath(tt.podSpec, tt.container, tt.configPath)
+			if gotCM != tt.wantCMName || gotKey != tt.wantDataKey {
+				t.Errorf("findConfigMapForPath() = (%q, %q), want (%q, %q)", gotCM, gotKey, tt.wantCMName, tt.wantDataKey)
+			}
+		})
+	}
+}
+
+func Test_parseManagedNamespacesFromConfigMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    map[string]string
+		dataKey string
+		want    *ManagedNamespaces
+		wantErr bool
+	}{
+		{
+			name:    "static namespaces as yaml sequence",
+			data:    map[string]string{"eck.yaml": "namespaces: [ns1,ns2]\n"},
+			dataKey: "eck.yaml",
+			want:    &ManagedNamespaces{All: false, Static: []string{"ns1", "ns2"}},
+		},
+		{
+			name:    "static namespaces as yaml list",
+			data:    map[string]string{"eck.yaml": "namespaces:\n- ns1\n- ns2\n"},
+			dataKey: "eck.yaml",
+			want:    &ManagedNamespaces{All: false, Static: []string{"ns1", "ns2"}},
+		},
+		{
+			name:    "namespace-selector",
+			data:    map[string]string{"eck.yaml": "namespace-selector:\n  matchLabels:\n    eck-managed: \"true\"\n"},
+			dataKey: "eck.yaml",
+			want: &ManagedNamespaces{
+				All:      false,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"eck-managed": "true"}},
+			},
+		},
+		{
+			name:    "custom data key (e.g. operator.yaml)",
+			data:    map[string]string{"operator.yaml": "namespaces: [ns1,ns2]\n"},
+			dataKey: "operator.yaml",
+			want:    &ManagedNamespaces{All: false, Static: []string{"ns1", "ns2"}},
+		},
+		{
+			name:    "key not present returns error",
+			data:    map[string]string{"other.yaml": "namespaces: [ns1]\n"},
+			dataKey: "eck.yaml",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid yaml returns error",
+			data:    map[string]string{"eck.yaml": "namespaces: [\n"},
+			dataKey: "eck.yaml",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "namespaces with unexpected type returns error",
+			data:    map[string]string{"eck.yaml": "namespaces: 123\n"},
+			dataKey: "eck.yaml",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "no namespace restriction returns nil without error",
+			data:    map[string]string{"eck.yaml": "operator-namespace: elastic-system\n"},
+			dataKey: "eck.yaml",
+			want:    nil,
+		},
+		{
+			name:    "empty namespace list returns nil without error",
+			data:    map[string]string{"eck.yaml": "namespaces: []\n"},
+			dataKey: "eck.yaml",
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseManagedNamespacesFromConfigMap(tt.data, tt.dataKey)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseManagedNamespacesFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseManagedNamespacesFromConfigMap() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_annotationKeyFromFieldPath(t *testing.T) {
+	tests := []struct {
+		fieldPath string
+		want      string
+	}{
+		{fieldPath: "metadata.annotations['olm.targetNamespaces']", want: "olm.targetNamespaces"},
+		{fieldPath: "metadata.annotations['olm.operatorNamespace']", want: "olm.operatorNamespace"},
+		{fieldPath: "metadata.name", want: ""},
+		{fieldPath: "metadata.namespace", want: ""},
+		{fieldPath: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fieldPath, func(t *testing.T) {
+			if got := annotationKeyFromFieldPath(tt.fieldPath); got != tt.want {
+				t.Errorf("annotationKeyFromFieldPath(%q) = %q, want %q", tt.fieldPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveEnvValueFromFieldRef(t *testing.T) {
+	podMeta := metav1.ObjectMeta{
+		Annotations: map[string]string{"olm.targetNamespaces": "ns1,ns2"},
+	}
+	src := &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			FieldPath: "metadata.annotations['olm.targetNamespaces']",
+		},
+	}
+	if got := resolveEnvValueFromFieldRef(podMeta, src); got != "ns1,ns2" {
+		t.Errorf("resolveEnvValueFromFieldRef() = %q, want %q", got, "ns1,ns2")
+	}
+}
+
+func Test_detectManagedNamespaces(t *testing.T) {
+	const operatorImage = "docker.elastic.co/eck/eck-operator:2.14.0"
+	tests := []struct {
+		name        string
+		podTemplate corev1.PodTemplateSpec
+		want        ManagedNamespaces
+	}{
+		{
+			name: "arg wins over env var",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Args:  []string{"--namespaces=ns-from-arg"},
+						Env:   []corev1.EnvVar{{Name: "NAMESPACES", Value: "ns-from-env"}},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: false, Static: []string{"ns-from-arg"}},
+		},
+		{
+			name: "env wins over config file",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Args:  []string{"--config=/conf/eck.yaml"},
+						Env:   []corev1.EnvVar{{Name: "NAMESPACES", Value: "ns-from-env"}},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: false, Static: []string{"ns-from-env"}},
+		},
+		{
+			name: "ValueFrom reads annotation from pod template metadata",
+			podTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"olm.targetNamespaces": "ns1,ns2"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Env: []corev1.EnvVar{{
+							Name: "NAMESPACES",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.annotations['olm.targetNamespaces']",
+								},
+							},
+						}},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: false, Static: []string{"ns1", "ns2"}},
+		},
+		{
+			name: "ValueFrom with no annotation in pod template returns all",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Env: []corev1.EnvVar{{
+							Name: "NAMESPACES",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.annotations['olm.targetNamespaces']",
+								},
+							},
+						}},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: true},
+		},
+		{
+			name: "no arg no env no volume returns all",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "manager",
+						Image: operatorImage,
+						Args:  []string{"--config=/conf/eck.yaml"},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: true},
+		},
+		{
+			name: "no manager container returns all",
+			podTemplate: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "sidecar",
+						Image: "some-other-image:latest",
+						Args:  []string{"--namespaces=ns1"},
+					}},
+				},
+			},
+			want: ManagedNamespaces{All: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectManagedNamespaces(nil, "elastic-system", tt.podTemplate)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("detectManagedNamespaces() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/operator_test.go
+++ b/internal/operator_test.go
@@ -392,37 +392,70 @@ func Test_parseManagedNamespacesFromConfigMap(t *testing.T) {
 	}
 }
 
-func Test_annotationKeyFromFieldPath(t *testing.T) {
-	tests := []struct {
-		fieldPath string
-		want      string
-	}{
-		{fieldPath: "metadata.annotations['olm.targetNamespaces']", want: "olm.targetNamespaces"},
-		{fieldPath: "metadata.annotations['olm.operatorNamespace']", want: "olm.operatorNamespace"},
-		{fieldPath: "metadata.name", want: ""},
-		{fieldPath: "metadata.namespace", want: ""},
-		{fieldPath: "", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.fieldPath, func(t *testing.T) {
-			if got := annotationKeyFromFieldPath(tt.fieldPath); got != tt.want {
-				t.Errorf("annotationKeyFromFieldPath(%q) = %q, want %q", tt.fieldPath, got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_resolveEnvValueFromFieldRef(t *testing.T) {
 	podMeta := metav1.ObjectMeta{
-		Annotations: map[string]string{"olm.targetNamespaces": "ns1,ns2"},
-	}
-	src := &corev1.EnvVarSource{
-		FieldRef: &corev1.ObjectFieldSelector{
-			FieldPath: "metadata.annotations['olm.targetNamespaces']",
+		Annotations: map[string]string{
+			"olm.targetNamespaces":  "ns1,ns2",
+			"olm.operatorNamespace": "elastic-system",
 		},
 	}
-	if got := resolveEnvValueFromFieldRef(podMeta, src); got != "ns1,ns2" {
-		t.Errorf("resolveEnvValueFromFieldRef() = %q, want %q", got, "ns1,ns2")
+	tests := []struct {
+		name string
+		src  *corev1.EnvVarSource
+		want string
+	}{
+		{
+			name: "annotation key resolved",
+			src: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['olm.targetNamespaces']",
+			}},
+			want: "ns1,ns2",
+		},
+		{
+			name: "second annotation key resolved",
+			src: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['olm.operatorNamespace']",
+			}},
+			want: "elastic-system",
+		},
+		{
+			name: "non-annotation fieldPath returns empty",
+			src: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.name",
+			}},
+			want: "",
+		},
+		{
+			name: "metadata.namespace returns empty",
+			src: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.namespace",
+			}},
+			want: "",
+		},
+		{
+			name: "missing annotation key returns empty",
+			src: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['olm.nonExistent']",
+			}},
+			want: "",
+		},
+		{
+			name: "nil src returns empty",
+			src:  nil,
+			want: "",
+		},
+		{
+			name: "nil FieldRef returns empty",
+			src:  &corev1.EnvVarSource{FieldRef: nil},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveEnvValueFromFieldRef(podMeta, tt.src); got != tt.want {
+				t.Errorf("resolveEnvValueFromFieldRef() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -29,7 +29,7 @@ func logVersion(v *version.Version) {
 	logger.Printf("ECK version is %s\n", s)
 }
 
-func findOperatorStatefulSet(c *kubernetes.Clientset, namespace string) (*appsv1.StatefulSet, error) {
+func findOperatorStatefulSet(c kubernetes.Interface, namespace string) (*appsv1.StatefulSet, error) {
 	// we use the control-plane label since ECK version 1.0
 	ssets, err := c.AppsV1().StatefulSets(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "control-plane=elastic-operator"})
 	if err != nil {

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,7 +7,6 @@ package internal
 import (
 	"context"
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -28,38 +27,6 @@ func logVersion(v *version.Version) {
 		s = "unknown"
 	}
 	logger.Printf("ECK version is %s\n", s)
-}
-
-// detectECKVersion tries to detect the ECK version by inspecting the ECK operator stateful set or deployment.
-func detectECKVersion(c *kubernetes.Clientset, namespace, userSpecifiedVersion string) *version.Version {
-	if userSpecifiedVersion != "" {
-		parsed, err := version.ParseSemantic(userSpecifiedVersion)
-		if err != nil {
-			logger.Println(err.Error())
-			return fallbackMaxVersion
-		}
-		return parsed
-	}
-
-	statefulSet, err := findOperatorStatefulSet(c, namespace)
-	if err != nil {
-		logger.Println(err.Error())
-		return fallbackMaxVersion
-	}
-
-	// we were not able to find a StatefulSet we might be dealing with an ECK operator deployed via OLM
-	if statefulSet == nil {
-		return extractVersionFromDeployment(c, namespace)
-	}
-
-	// since version 1.3 ECK uses standard labels
-	versionLabel := statefulSet.Labels["app.kubernetes.io/version"]
-	parsed, err := version.ParseSemantic(versionLabel)
-	if err == nil {
-		return parsed
-	}
-
-	return extractVersionFromContainers(statefulSet.Spec.Template.Spec.Containers)
 }
 
 func findOperatorStatefulSet(c *kubernetes.Clientset, namespace string) (*appsv1.StatefulSet, error) {
@@ -106,21 +73,6 @@ func extractVersionFromContainers(containers []corev1.Container) *version.Versio
 		}
 	}
 	return fallbackMaxVersion
-}
-
-// extractVersionFromDeployment tries to extract version information from a deployment as it is typically used in ECK installations via OLM.
-func extractVersionFromDeployment(c *kubernetes.Clientset, namespace string) *version.Version {
-	deployment, err := c.AppsV1().Deployments(namespace).Get(context.Background(), "elastic-operator", metav1.GetOptions{})
-	if err != nil {
-		logger.Println(fmt.Errorf("operator statefulset not found, checking for OLM deployment but failed: %w", err).Error())
-		return fallbackMaxVersion
-	}
-	v, err := extractVersionFromOLMMetadata(deployment.Labels)
-	if err != nil {
-		logger.Println("ECK operator not found in OLM metadata checking container image as last resort")
-		return extractVersionFromContainers(deployment.Spec.Template.Spec.Containers)
-	}
-	return v
 }
 
 func extractVersionFromOLMMetadata(labels map[string]string) (*version.Version, error) {


### PR DESCRIPTION
## Summary

Implements [#270](https://github.com/elastic/eck-diagnostics/issues/270).

Adds `operators.json` to the diagnostic archive - a JSON array with one entry per operator namespace, capturing the version, how the operator was installed, and which namespaces it manages. Also adds `namespaces.json` (full cluster namespace list) to the archive and emits a warning when the operator's managed namespaces are not fully covered by `--resources-namespaces`, so users know the diagnostic may be incomplete.

All detection is read-only: it inspects the operator StatefulSet or Deployment pod template spec (args, env, ConfigMap volumes) and resolves a single ConfigMap when a config file is mounted. No `kubectl exec` is required.

## Changed

- **`operators.json` added to archive** - a JSON array of operator objects, one per `--operator-namespaces` entry. Each object carries `namespace`, `version` (semver or `"unknown"`), `install_method` (`helm` / `yaml` / `olm` / `unknown"`), and `managed_namespaces` (`all: true` when unrestricted; `static: [...]` for a fixed list; `selector: {...}` for the enterprise label-selector).

- **`namespaces.json` added to archive** - full cluster namespace list, included at the root level alongside `nodes.json`.

- **Missing-namespace warning** - after resolving managed namespaces for every operator, the tool cross-references them against the namespaces being collected and logs a `WARNING` for any gap, directing the user to `--resources-namespaces`.

- **Install-method detection** - inferred from labels on the operator StatefulSet (`helm.sh/chart` → helm, `control-plane=elastic-operator` → yaml) or Deployment (`olm.owner` → olm).

- **Managed-namespace detection** - follows Viper's precedence (`--namespaces` arg > `NAMESPACES` env var > `namespaces:`/`namespace-selector:` in the config file). OLM's `ValueFrom.FieldRef` for `NAMESPACES` is resolved from the pod template annotations (where OLM injects `olm.targetNamespaces`). ConfigMap volume tracing handles directory mounts, `items` key→path remappings, and single-file `subPath` mounts. Warnings are emitted when the config source cannot be traced (e.g. mounted from a Secret) or when the ConfigMap cannot be read or parsed.