### PR TITLE
Fix Renovate grouping and add Makefile go install tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ generate-notice.txt: $(GOBIN)/go-licence-detector
 # tool dependencies
 
 $(GOBIN)/go-licence-detector:
-	@ go install go.elastic.co/go-licence-detector@v0.7.0
+	@ go install go.elastic.co/go-licence-detector@v0.10.0
 
 $(GOBIN)/golangci-lint:
-	@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+	@ go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1

--- a/renovate.json
+++ b/renovate.json
@@ -89,7 +89,7 @@
         "actions/go-versions",
         "docker.io/library/golang",
         "docker.elastic.co/wolfi/go",
-        "github.com/golangci/golangci-lint"
+        "/github.com/golangci/golangci-lint/"
       ],
       "groupName": "go"
     },
@@ -100,5 +100,16 @@
       ]
     }
   ],
-  "separateMajorMinor": true
+  "separateMajorMinor": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "go install (?<depName>github\\.com/golangci/golangci-lint(?:/v\\d+)?)/cmd/golangci-lint@(?<currentValue>[^\\s]+)",
+        "go install (?<depName>[^@]+)@(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "go"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,7 @@
       "matchPackageNames": [
         "go",
         "golang",
+        "actions/go-versions",
         "docker.io/library/golang",
         "docker.elastic.co/wolfi/go",
         "github.com/golangci/golangci-lint"


### PR DESCRIPTION
## Summary

Fix Renovate grouping so that Go version bumps in GitHub Actions workflow files land in the same PR as other Go toolchain updates, add Makefile tracking for `go install` tool dependencies, and bump both tools to their latest versions.

## Changes

- **`actions/go-versions` added to the `go` group.**
Renovate uses `actions/go-versions` as the datasource package name for `go-version:` inputs in `actions/setup-go` workflow steps, so without this entry the GitHub Actions Go version bump was landing in the "all ungrouped dependencies" PR instead of the `go` group PR.

- **`github.com/golangci/golangci-lint` matched via regex.**
Changed the exact string match to a regex pattern (`/github.com/golangci/golangci-lint/`) so it matches both the bare module path and the `/v2/cmd/golangci-lint` import path produced by the custom manager.

- **Custom manager added for Makefile `go install` lines.**
Adds a `customManagers` regex entry that tracks `go install module@version` lines in the Makefile. A dedicated pattern for golangci-lint captures the module path (`github.com/golangci/golangci-lint/v2`) rather than the full import path, which is required for correct Go module proxy lookups. A generic fallback pattern handles other `go install` lines such as `go-licence-detector`.

- **`golangci-lint` bumped to `v2.13.1`** from `v2.11.4`.

- **`go-licence-detector` bumped to `v0.10.0`** from `v0.7.0`.
